### PR TITLE
Use single key shape

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "@babel/preset-env": "^7.4.1",
     "@babel/preset-typescript": "^7.3.3",
     "@types/ledgerhq__hw-transport-u2f": "^4.21.1",
-    "@types/scrypt-async": "^1.3.0",
     "@types/sinon": "^7.0.11",
     "@types/stellar-sdk": "^0.11.1",
     "babel-jest": "^24.5.0",

--- a/src/KeyHelpers.test.ts
+++ b/src/KeyHelpers.test.ts
@@ -1,49 +1,6 @@
 import { EncryptedKey, KeyType } from "./types";
 
-import { getKeyMetadata, isLedgerKey } from "./KeyHelpers";
-
-describe("isLedgerKey", () => {
-  test("ledger key", () => {
-    expect(
-      isLedgerKey({
-        type: KeyType.plaintextKey,
-        publicKey: "AVACYN",
-        path: "seraph/sanctuary",
-      }),
-    ).toEqual(true);
-  });
-  test("private key", () => {
-    expect(
-      isLedgerKey({
-        type: KeyType.plaintextKey,
-        publicKey: "AVACYN",
-        privateKey: "ARCHANGEL",
-      }),
-    ).toEqual(false);
-  });
-  test("encrypted ledger key", () => {
-    expect(
-      isLedgerKey({
-        type: KeyType.plaintextKey,
-        publicKey: "AVACYN",
-        path: "seraph/sanctuary",
-        encrypterName: "test",
-        salt: "salty salt",
-      }),
-    ).toEqual(true);
-  });
-  test("encrypted private key", () => {
-    expect(
-      isLedgerKey({
-        type: KeyType.plaintextKey,
-        publicKey: "AVACYN",
-        encrypterName: "test",
-        salt: "salty salt",
-        encryptedPrivateKey: "ARCHANGEL",
-      }),
-    ).toEqual(false);
-  });
-});
+import { getKeyMetadata } from "./KeyHelpers";
 
 describe("getKeyMetadata", () => {
   test("ledger key", () => {

--- a/src/KeyHelpers.ts
+++ b/src/KeyHelpers.ts
@@ -1,17 +1,4 @@
-import {
-  EncryptedKey,
-  EncryptedLedgerKey,
-  EncryptedPlaintextKey,
-  KeyMetadata,
-  LedgerKey,
-  PlaintextKey,
-} from "./types";
-
-export function isLedgerKey(
-  key: LedgerKey | PlaintextKey | EncryptedLedgerKey | EncryptedPlaintextKey,
-): key is LedgerKey | EncryptedLedgerKey {
-  return (key as LedgerKey).path !== undefined;
-}
+import { EncryptedKey, KeyMetadata } from "./types";
 
 export function getKeyMetadata({
   encryptedKey,
@@ -22,11 +9,9 @@ export function getKeyMetadata({
   creationTime: number;
   modifiedTime: number;
 }): KeyMetadata {
+  const { encryptedPrivateKey, salt, ...keyWithoutDetails } = encryptedKey;
   return {
-    encrypterName: encryptedKey.encrypterName,
-    type: encryptedKey.type,
-    publicKey: encryptedKey.publicKey,
-    path: isLedgerKey(encryptedKey) ? encryptedKey.path : undefined,
+    ...keyWithoutDetails,
     creationTime,
     modifiedTime,
   };

--- a/src/keyTypeHandlers/ledger.ts
+++ b/src/keyTypeHandlers/ledger.ts
@@ -3,7 +3,6 @@ import LedgerTransport from "@ledgerhq/hw-transport-u2f";
 import { Transaction } from "stellar-base";
 import StellarSdk from "stellar-sdk";
 
-import { isLedgerKey } from "../KeyHelpers";
 import { Key, KeyType, KeyTypeHandler } from "../types";
 
 export const ledgerHandler: KeyTypeHandler = {
@@ -15,7 +14,7 @@ export const ledgerHandler: KeyTypeHandler = {
     transaction: Transaction;
     key: Key;
   }) {
-    if (!isLedgerKey(key)) {
+    if (key.privateKey !== "") {
       throw new Error(
         `Non-ledger key sent to ledger handler: ${JSON.stringify(
           key.publicKey,

--- a/src/keyTypeHandlers/plaintextKey.ts
+++ b/src/keyTypeHandlers/plaintextKey.ts
@@ -1,7 +1,7 @@
 import { Transaction } from "stellar-base";
 import StellarSdk from "stellar-sdk";
 
-import { Key, KeyType, KeyTypeHandler, PlaintextKey } from "../types";
+import { Key, KeyType, KeyTypeHandler } from "../types";
 
 export const plaintextKeyHandler: KeyTypeHandler = {
   keyType: KeyType.ledger,
@@ -12,7 +12,7 @@ export const plaintextKeyHandler: KeyTypeHandler = {
     transaction: Transaction;
     key: Key;
   }) {
-    if ((key as PlaintextKey).privateKey === undefined) {
+    if (key.privateKey === "") {
       throw new Error(
         `Non-plaintext key sent to plaintext handler: ${JSON.stringify(
           key.publicKey,
@@ -20,9 +20,7 @@ export const plaintextKeyHandler: KeyTypeHandler = {
       );
     }
 
-    const keyPair = StellarSdk.Keypair.fromSecret(
-      (key as PlaintextKey).privateKey,
-    );
+    const keyPair = StellarSdk.Keypair.fromSecret(key.privateKey);
     transaction.sign(keyPair);
 
     return Promise.resolve(transaction);

--- a/src/modules.d.ts
+++ b/src/modules.d.ts
@@ -1,1 +1,2 @@
 declare module "@ledgerhq/hw-app-str";
+declare module "scrypt-async";

--- a/src/plugins/IdentityEncrypter.ts
+++ b/src/plugins/IdentityEncrypter.ts
@@ -1,6 +1,4 @@
-import { isLedgerKey } from "../KeyHelpers";
-
-import { EncryptedKey, Key, PlaintextKey } from "../types";
+import { EncryptedKey, Key } from "../types";
 
 const NAME = "IdentityEncrypter";
 
@@ -10,15 +8,7 @@ const NAME = "IdentityEncrypter";
 export const IdentityEncrypter = {
   name: NAME,
   encryptKey({ key }: { key: Key }) {
-    if (isLedgerKey(key)) {
-      return Promise.resolve({
-        ...key,
-        encrypterName: NAME,
-        salt: "identity",
-      });
-    }
-
-    const { privateKey, ...secretlessKey } = key as PlaintextKey;
+    const { privateKey, ...secretlessKey } = key;
 
     return Promise.resolve({
       ...secretlessKey,

--- a/src/plugins/ScryptEncrypter.test.ts
+++ b/src/plugins/ScryptEncrypter.test.ts
@@ -1,4 +1,6 @@
-import { ScryptEncrypter } from "./ScryptEncrypter";
+import StellarSdk from "stellar-sdk";
+
+import { NONCE_BYTES, ScryptEncrypter } from "./ScryptEncrypter";
 
 import { KeyType } from "../types";
 
@@ -16,6 +18,48 @@ test("encrypts and decrypts a key", async () => {
   expect(encryptedKey).toBeTruthy();
   expect(encryptedKey.encryptedPrivateKey).toBeTruthy();
   expect(encryptedKey.encryptedPrivateKey).not.toEqual(key.privateKey);
+
+  const decryptedKey = await ScryptEncrypter.decryptKey({
+    encryptedKey,
+    password,
+  });
+
+  expect(decryptedKey).toBeTruthy();
+  expect(decryptedKey.privateKey).not.toEqual(encryptedKey.encryptedPrivateKey);
+  expect(decryptedKey.privateKey).toEqual(key.privateKey);
+});
+
+test("encrypts and decrypts a StellarX seed", async () => {
+  const seed = "SCHKKYK3B3MPQKDTUVS37WSVHJ7EY6YRAGKOMOZJUOOMKVXTHTHBPZVL";
+  const account = StellarSdk.Keypair.fromSecret(seed);
+
+  const key = {
+    type: KeyType.plaintextKey,
+    publicKey: account.publicKey(),
+    privateKey: seed,
+  };
+
+  const password = "hello";
+  const salt = "salty";
+
+  const nonce = new Uint8Array(NONCE_BYTES);
+  nonce.fill(42);
+
+  const encryptedKey = await ScryptEncrypter.encryptKey({
+    key,
+    password,
+    salt,
+    nonce,
+  });
+
+  expect(encryptedKey).toBeTruthy();
+  expect(encryptedKey.encryptedPrivateKey).toBeTruthy();
+  expect(encryptedKey.encryptedPrivateKey).not.toEqual(key.privateKey);
+
+  expect(encryptedKey.encryptedPrivateKey).toEqual(
+    "ASoqKioqKioqKioqKioqKioqKioqKioqKgjCVz5H3mKHykeuO6GA8KKJSQrTu9D9Gt8nhO" +
+      "R7u3iccJc+jV768SEGOtWnwU6x4o46LxhKI8nQGMahV4JpqruESNW8vwt0OQ==",
+  );
 
   const decryptedKey = await ScryptEncrypter.decryptKey({
     encryptedKey,

--- a/src/plugins/ScryptEncrypter.test.ts
+++ b/src/plugins/ScryptEncrypter.test.ts
@@ -12,12 +12,22 @@ test("encrypts and decrypts a key", async () => {
   };
 
   const password = "This is a really cool password and is good";
+  const salt = "Also this salt is really key, and good";
+  const nonce = new Uint8Array(NONCE_BYTES).fill(42);
 
-  const encryptedKey = await ScryptEncrypter.encryptKey({ key, password });
+  const encryptedKey = await ScryptEncrypter.encryptKey({
+    key,
+    password,
+    salt,
+    nonce,
+  });
 
   expect(encryptedKey).toBeTruthy();
   expect(encryptedKey.encryptedPrivateKey).toBeTruthy();
   expect(encryptedKey.encryptedPrivateKey).not.toEqual(key.privateKey);
+  expect(encryptedKey.encryptedPrivateKey).toEqual(
+    "ASoqKioqKioqKioqKioqKioqKioqKioqKghXdTQ4aKmd0WIKwT5YjOCtN95jMeXe1UI=",
+  );
 
   const decryptedKey = await ScryptEncrypter.decryptKey({
     encryptedKey,
@@ -41,9 +51,7 @@ test("encrypts and decrypts a StellarX seed", async () => {
 
   const password = "hello";
   const salt = "salty";
-
-  const nonce = new Uint8Array(NONCE_BYTES);
-  nonce.fill(42);
+  const nonce = new Uint8Array(NONCE_BYTES).fill(42);
 
   const encryptedKey = await ScryptEncrypter.encryptKey({
     key,

--- a/src/plugins/ScryptEncrypter.test.ts
+++ b/src/plugins/ScryptEncrypter.test.ts
@@ -1,6 +1,6 @@
 import { ScryptEncrypter } from "./ScryptEncrypter";
 
-import { EncryptedPlaintextKey, KeyType } from "../types";
+import { KeyType } from "../types";
 
 test("encrypts and decrypts a key", async () => {
   const key = {
@@ -14,12 +14,8 @@ test("encrypts and decrypts a key", async () => {
   const encryptedKey = await ScryptEncrypter.encryptKey({ key, password });
 
   expect(encryptedKey).toBeTruthy();
-  expect(
-    (encryptedKey as EncryptedPlaintextKey).encryptedPrivateKey,
-  ).toBeTruthy();
-  expect(
-    (encryptedKey as EncryptedPlaintextKey).encryptedPrivateKey,
-  ).not.toEqual(key.privateKey);
+  expect(encryptedKey.encryptedPrivateKey).toBeTruthy();
+  expect(encryptedKey.encryptedPrivateKey).not.toEqual(key.privateKey);
 
   const decryptedKey = await ScryptEncrypter.decryptKey({
     encryptedKey,
@@ -27,8 +23,6 @@ test("encrypts and decrypts a key", async () => {
   });
 
   expect(decryptedKey).toBeTruthy();
-  expect(decryptedKey.privateKey).not.toEqual(
-    (encryptedKey as EncryptedPlaintextKey).encryptedPrivateKey,
-  );
+  expect(decryptedKey.privateKey).not.toEqual(encryptedKey.encryptedPrivateKey);
   expect(decryptedKey.privateKey).toEqual(key.privateKey);
 });

--- a/src/plugins/ScryptEncrypter.ts
+++ b/src/plugins/ScryptEncrypter.ts
@@ -2,15 +2,7 @@ import scrypt from "scrypt-async";
 import nacl from "tweetnacl";
 import naclutil from "tweetnacl-util";
 
-import { isLedgerKey } from "../KeyHelpers";
-
-import {
-  EncryptedKey,
-  EncryptedLedgerKey,
-  EncryptedPlaintextKey,
-  Key,
-  PlaintextKey,
-} from "../types";
+import { EncryptedKey, Key } from "../types";
 
 const NAME = "ScryptEncrypter";
 
@@ -74,15 +66,7 @@ export const ScryptEncrypter = {
   }): Promise<EncryptedKey> {
     const salt = generateSalt();
 
-    if (isLedgerKey(key)) {
-      return Promise.resolve({
-        ...key,
-        encrypterName: NAME,
-        salt,
-      } as EncryptedLedgerKey);
-    }
-
-    const { privateKey, ...secretlessKey } = key as PlaintextKey;
+    const { privateKey, ...secretlessKey } = key;
 
     const nonceBytes = nacl.randomBytes(NONCE_BYTES);
     const scryptedPass = await scryptPass({ password, salt });
@@ -107,7 +91,7 @@ export const ScryptEncrypter = {
       encryptedPrivateKey,
       encrypterName: NAME,
       salt,
-    } as EncryptedPlaintextKey);
+    });
   },
   async decryptKey({
     encryptedKey,
@@ -116,12 +100,7 @@ export const ScryptEncrypter = {
     encryptedKey: EncryptedKey;
     password: string;
   }) {
-    const {
-      encrypterName,
-      salt,
-      encryptedPrivateKey,
-      ...key
-    } = encryptedKey as any;
+    const { encrypterName, salt, encryptedPrivateKey, ...key } = encryptedKey;
 
     const scryptedPass = await scryptPass({ password, salt });
 

--- a/src/types/keys.ts
+++ b/src/types/keys.ts
@@ -5,53 +5,43 @@ export enum KeyType {
   plaintextKey = "plaintextKey",
 }
 
-interface BaseKey {
+export interface BaseKey {
   type: KeyType | string;
   publicKey: string;
-  extra?: string;
+  path?: string;
+  extra?: any;
 }
 
-export interface LedgerKey extends BaseKey {
-  path: string;
-}
-
-export interface PlaintextKey extends BaseKey {
+/**
+ * There is one unencrypted key interface, which should work with all key types.
+ * That way, plugins don't have to know what key type there is, they just work
+ * the same on all of them.
+ *
+ * `privateKey` is required, but it should be an empty string if the key type
+ * doesn't have any secrets (like a ledger key).
+ *
+ * `extra` is an arbitrary store of additional metadata, to be used for any and
+ * all future exotic key types.
+ */
+export interface Key extends BaseKey {
   privateKey: string;
 }
 
-interface BaseEncryptedKey extends BaseKey {
+/**
+ * The encrypted key is the exact same shape as the key, except minus secret
+ * information and plus encrypted information.
+ */
+export interface EncryptedKey extends BaseKey {
+  encryptedPrivateKey: string;
   encrypterName: string;
   salt: string;
 }
 
-export interface EncryptedLedgerKey extends BaseEncryptedKey {
-  path: string;
-}
-export interface EncryptedPlaintextKey extends BaseEncryptedKey {
-  encryptedPrivateKey: string;
-}
-
 /**
- * The whole, unencrypted blob. Should be enough information to sign a
- * key alone, or with a library that reaches out to a hardware device.
- * The "extra" property is for miscellaneous notes about the key.
- */
-export type Key = LedgerKey | PlaintextKey;
-
-/**
- * A blob that's similar to, but not completely like, the key. (The difference
- * is that if there's a secret in the key, that property is absent and an
- * encrypted version of that field is present.)
- */
-export type EncryptedKey = EncryptedLedgerKey | EncryptedPlaintextKey;
-
-/**
- * Metadata about the key, without any private information.
+ * Metadata about the key and when it was changed.
  */
 export interface KeyMetadata extends BaseKey {
-  type: KeyType | string;
   encrypterName: string;
-  path?: string;
   creationTime: number;
   modifiedTime: number;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1028,11 +1028,6 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-11.11.4.tgz#8808bd5a82bbf6f5d412eff1c228d178e7c24bb3"
   integrity sha512-02tIL+QIi/RW4E5xILdoAMjeJ9kYq5t5S2vciUdFPXv/ikFTb0zK8q9vXkg4+WAJuYXGiVT1H28AkD2C+IkXVw==
 
-"@types/scrypt-async@^1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@types/scrypt-async/-/scrypt-async-1.3.0.tgz#bdc7bd89fde46de3eb1684afee0dbbb94f058b9b"
-  integrity sha512-1g5RDIq2sLlbn3bk1RnXCZWV2gqv7A2ov5ivvcjvICUUtXWlqR95Q9Iio3/EhAdZc4Otat41rnK+bnTGieycSQ==
-
 "@types/shelljs@^0.8.0":
   version "0.8.3"
   resolved "https://registry.yarnpkg.com/@types/shelljs/-/shelljs-0.8.3.tgz#f713f312dbae49ab5025290007e71ea32998e9a9"


### PR DESCRIPTION
(1) Use a single, forward-compatible key shape so consumers can design their infrastructure around it.
(2) Add tests, including one from StellarX, and test the output to test that the encryption algo doesn't change.
(3) Break out scrypt encrypter logic into its own lib.