### PR TITLE
Fix some issues with KeyManager

### DIFF
--- a/src/KeyManager.ts
+++ b/src/KeyManager.ts
@@ -187,7 +187,7 @@ export class KeyManager {
       }),
     );
 
-    return this.keyStore.storeKeys(newKeys);
+    return this.keyStore.updateKeys(newKeys);
   }
 
   private _readFromCache(publicKey: string): Key | undefined {

--- a/src/KeyManager.ts
+++ b/src/KeyManager.ts
@@ -95,7 +95,7 @@ export class KeyManager {
     const encryptedKey = await encrypterObj.encryptKey({ key, password });
     const keyMetadata = await this.keyStore.storeKeys([encryptedKey]);
 
-    this._writeIndexache(key.publicKey, key);
+    this._writeIndexCache(key.publicKey, key);
 
     return keyMetadata[0];
   }
@@ -119,7 +119,7 @@ export class KeyManager {
    */
   public async removeKey(publicKey: string): Promise<KeyMetadata | undefined> {
     const res = await this.keyStore.removeKey(publicKey);
-    this._writeIndexache(publicKey, undefined);
+    this._writeIndexCache(publicKey, undefined);
     return res;
   }
 
@@ -148,7 +148,7 @@ export class KeyManager {
 
       const encrypterObj = this.encrypterMap[encryptedKey.encrypterName];
       key = await encrypterObj.decryptKey({ encryptedKey, password });
-      this._writeIndexache(publicKey, key);
+      this._writeIndexCache(publicKey, key);
     }
 
     const keyHandler = this.keyHandlerMap[key.type];
@@ -178,7 +178,7 @@ export class KeyManager {
           password: oldPassword,
         });
 
-        this._writeIndexache(encryptedKey.publicKey, decryptedKey);
+        this._writeIndexCache(encryptedKey.publicKey, decryptedKey);
 
         return encrypterName.encryptKey({
           key: decryptedKey,
@@ -198,7 +198,7 @@ export class KeyManager {
     return this.keyCache[publicKey];
   }
 
-  private _writeIndexache(publicKey: string, key: Key | undefined) {
+  private _writeIndexCache(publicKey: string, key: Key | undefined) {
     if (this.shouldCache && key) {
       this.keyCache[publicKey] = key;
     }

--- a/src/plugins/MemoryKeyStore.ts
+++ b/src/plugins/MemoryKeyStore.ts
@@ -58,11 +58,15 @@ export class MemoryKeyStore implements KeyStore {
   }
 
   public updateKeys(keys: EncryptedKey[]) {
-    const valid = keys.every(
-      (encryptedKey: EncryptedKey) => !!this.keyStore[encryptedKey.publicKey],
+    const invalidKeys: EncryptedKey[] = keys.filter(
+      (encryptedKey: EncryptedKey) => !this.keyStore[encryptedKey.publicKey],
     );
-    if (!valid) {
-      return Promise.reject("some key does not exist");
+    if (invalidKeys.length) {
+      return Promise.reject(
+        `Some keys couldn't be found in the keystore: ${invalidKeys
+          .map((k) => k.publicKey)
+          .join(", ")}`,
+      );
     }
 
     const keysMetadata = keys.map((encryptedKey: EncryptedKey) => {


### PR DESCRIPTION
* Fix typos
* After changing passwords, run an update instead of a store
* Improve the error message when a dev tries to update a key that's not in the store

TODO: Don't error out when a key isn't in the store during an update; instead, send those to `storeKey`