### PR TITLE
DataProvider should always return reframed data

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,7 @@ clarity.
 ```js
 import { Data } from "@stellar/wallet-sdk";
 
-const {
-  getTokenIdentifier,
-  getBalanceIdentifier,
-  reframeEffect,
-  DataProvider,
-} = Data;
+const { getTokenIdentifier, getBalanceIdentifier, DataProvider } = Data;
 
 // You'll use your DataProvider instance to ask for data from Stellar.
 const dataProvider = new DataProvider({

--- a/documentation/src/App.js
+++ b/documentation/src/App.js
@@ -68,7 +68,6 @@ const LIBRARY_EXPORTS = {
   testKeyStore: 1,
   getTokenIdentifier: 1,
   getBalanceIdentifier: 1,
-  reframeEffect: 1,
   DataProvider: 1,
   KeyManager: 1,
   KeyManagerPlugins: 1,

--- a/plans/data.md
+++ b/plans/data.md
@@ -17,7 +17,6 @@ const StellarWallets = {
 
     // stateless functions
     getTokenIdentifier,
-    reframeEffect,
 
     // this is a class, so you can set the Horizon server
     // we want to hit
@@ -134,19 +133,6 @@ This is useful for people to test token equality, create indices, etc.
 function getTokenIdentifier(token: Token): string {
   return `#{token.code}:#{token.issuer.key}`;
 }
-```
-
-### Reframe an effect from the point of view of an account
-
-Effect-like objects by default have a "sender" and "receiver", but most of the
-time, wallets only care about showing "what did YOU send/receive." So this is a
-way of turning "senderAmount // receiverAmount" into "amount // price".
-
-```typescript
-function reframeEffect(
-  observerAccount: Account,
-  effect: Effect,
-): ReframedEffect;
 ```
 
 ## Getters and watchers

--- a/plans/data.md
+++ b/plans/data.md
@@ -1,5 +1,15 @@
 # Data API
 
+The Data API is meant to return readable, understandable processed Stellar data
+from the network.
+
+Some things we did to make the data more understandable:
+
+- Trade data is from the point of view of the account you use to initiate the
+  `DataProvider`. That means instead of indicating "sender" and "receiver",
+  either of which could be your account, trades indicate a "payment token" (what
+  you send) and an "incoming token" (what you receive).
+
 ## API surface
 
 ```typescript
@@ -95,16 +105,6 @@ interface Offer extends Effect {}
 
 interface Transfer extends Effect {
   transferType: string; // or enum? basically, is this the "create account" transfer
-}
-
-interface ReframedEffect {
-  id: string;
-  baseToken: Token;
-  token: Token;
-  amount: Big;
-  price: Token;
-  sender: Account;
-  timestamp: number;
 }
 
 interface Balance {

--- a/src/data/DataProvider.ts
+++ b/src/data/DataProvider.ts
@@ -101,7 +101,7 @@ export class DataProvider {
       .call()
       .then((data) => data.records);
 
-    return makeDisplayableTrades(trades);
+    return makeDisplayableTrades({ publicKey: this.accountKey }, trades);
   }
 
   /**

--- a/src/data/index.test.ts
+++ b/src/data/index.test.ts
@@ -1,112 +1,20 @@
-import BigNumber from "bignumber.js";
-import { AssetType } from "stellar-sdk";
+import { getTokenIdentifier } from "./";
 
-import { EffectType } from "../constants/data";
-import { reframeEffect } from "./";
-
-describe("reframeEffect", () => {
-  const observerAccount = {
-    publicKey: "OBSERVER",
-  };
-
-  const otherAccount = {
-    publicKey: "OTHER",
-  };
-
-  const nativeToken = {
-    type: "native" as AssetType.native,
-    code: "XLM",
-  };
-
-  const otherToken = {
-    type: "credit_alphanum12" as AssetType.credit12,
-    code: "CLUE",
-    issuer: {
-      key: "THRABEN",
-      name: "Thraben",
-      url: "http://thraben.gov",
-      hostName: "thraben",
-    },
-    anchorAsset: "CLUE",
-    numAccounts: new BigNumber(1000),
-    amount: new BigNumber(100000),
-    bidCount: new BigNumber(10),
-    askCount: new BigNumber(10),
-    spread: new BigNumber(2),
-  };
-
-  test("reframes effects: you're the receiver", () => {
-    /* 
-      In plain language: I sent someone 200 XLM for 2 CLUE tokens.
-      They were 
-    */
-    const effect = {
-      id: "id",
-      type: EffectType.trade,
-      senderToken: otherToken,
-      senderAccount: otherAccount,
-      senderAmount: new BigNumber(2),
-
-      receiverToken: nativeToken,
-      receiverAccount: observerAccount,
-      receiverAmount: new BigNumber(200),
-      timestamp: 1000,
-    };
-
-    expect(reframeEffect(observerAccount, effect)).toEqual({
-      id: "id",
-      type: EffectType.trade,
-      baseToken: nativeToken,
-      token: otherToken,
-      amount: new BigNumber(2),
-      price: new BigNumber(200),
-      sender: otherAccount,
-      timestamp: 1000,
-    });
-  });
-
-  test("reframes effects: you're the sender", () => {
-    /* 
-      In plain language: I sent someone 200 XLM for 2 CLUE tokens.
-    */
-    const effect = {
-      id: "id",
-      type: EffectType.trade,
-      receiverToken: otherToken,
-      receiverAccount: otherAccount,
-      receiverAmount: new BigNumber(2),
-
-      senderToken: nativeToken,
-      senderAccount: observerAccount,
-      senderAmount: new BigNumber(200),
-      timestamp: 1000,
-    };
-
-    expect(reframeEffect(observerAccount, effect)).toEqual({
-      id: "id",
-      type: EffectType.trade,
-      baseToken: nativeToken,
-      token: otherToken,
-      amount: new BigNumber(2),
-      price: new BigNumber(200),
-      sender: otherAccount,
-      timestamp: 1000,
-    });
-  });
-  test("sends back already-reframed effects", () => {
-    const reframedEffect = {
-      id: "id",
-      type: EffectType.trade,
-      baseToken: nativeToken,
-      token: otherToken,
-      amount: new BigNumber(2),
-      price: new BigNumber(200),
-      sender: otherAccount,
-      timestamp: 1000,
-    };
-
-    expect(reframeEffect(observerAccount, reframedEffect)).toEqual(
-      reframedEffect,
+describe("getTokenIdentifier", () => {
+  test("native element", () => {
+    expect(getTokenIdentifier({ type: "native", code: "XLM" })).toEqual(
+      "native",
     );
+  });
+  test("non-native element", () => {
+    expect(
+      getTokenIdentifier({
+        code: "BAT",
+        type: "credit_alphanum4",
+        issuer: {
+          key: "GBDEVU63Y6NTHJQQZIKVTC23NWLQVP3WJ2RI2OTSJTNYOIGICST6DUXR",
+        },
+      }),
+    ).toEqual("BAT:GBDEVU63Y6NTHJQQZIKVTC23NWLQVP3WJ2RI2OTSJTNYOIGICST6DUXR");
   });
 });

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -1,6 +1,6 @@
 import { Horizon } from "stellar-sdk";
 
-import { Account, AssetToken, Effect, ReframedEffect, Token } from "../types";
+import { AssetToken, Token } from "../types";
 
 /**
  * Get the string identifier for a token.
@@ -26,61 +26,4 @@ export function getBalanceIdentifier(balance: Horizon.BalanceLine): string {
   }
 
   return `${balance.asset_code}:${balance.asset_issuer}`;
-}
-
-function isReframedEffect(obj: any): obj is ReframedEffect {
-  return obj.baseToken !== undefined;
-}
-
-/**
- * Reframe a normal effect from a specific observer account's
- * perspective.
- */
-export function reframeEffect(
-  observerAccount: Account,
-  effect: Effect | ReframedEffect,
-): ReframedEffect {
-  // if the effect has already been reframed, we're done!
-  if (isReframedEffect(effect)) {
-    return effect;
-  }
-
-  const {
-    id,
-    senderToken,
-    receiverToken,
-    senderAccount,
-    receiverAccount,
-    senderAmount,
-    receiverAmount,
-    timestamp,
-    type,
-  } = effect;
-
-  const isObserverSender =
-    senderAccount.publicKey === observerAccount.publicKey;
-
-  if (isObserverSender) {
-    return {
-      id,
-      baseToken: senderToken,
-      token: receiverToken,
-      amount: receiverAmount,
-      price: senderAmount,
-      sender: receiverAccount,
-      timestamp,
-      type,
-    };
-  }
-
-  return {
-    id,
-    baseToken: receiverToken,
-    token: senderToken,
-    amount: senderAmount,
-    price: receiverAmount,
-    sender: senderAccount,
-    timestamp,
-    type,
-  };
 }

--- a/src/data/makeDisplayableOffers.test.ts
+++ b/src/data/makeDisplayableOffers.test.ts
@@ -32,7 +32,7 @@ it("makes offers from partial fill", () => {
       type: "credit_alphanum4",
       code: "USD",
       issuer: {
-        publicKey: "GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX",
+        key: "GDUKMGUGDZQK6YHYA5Z6AY2G4XDSZPSZ3SW5UN3ARVMO6QSRDWP5YLEX",
       },
     },
     incomingAmount: new BigNumber(2),

--- a/src/data/makeDisplayableOffers.test.ts
+++ b/src/data/makeDisplayableOffers.test.ts
@@ -9,12 +9,15 @@ import { makeDisplayableOffers } from "./makeDisplayableOffers";
 
 it("makes offers from partial fill", () => {
   const tradeResponse = parseResponse(TradesResponsePartialFill);
-  const offers = makeDisplayableOffers({
-    // @ts-ignore
-    offers: parseResponse(OffersResponse).records,
-    // @ts-ignore
-    tradeResponses: [tradeResponse.records],
-  });
+  const offers = makeDisplayableOffers(
+    { publicKey: "PHYREXIA" },
+    {
+      // @ts-ignore
+      offers: parseResponse(OffersResponse).records,
+      // @ts-ignore
+      tradeResponses: [tradeResponse.records],
+    },
+  );
 
   expect(offers[0]).toEqual({
     id: 76884793,

--- a/src/data/makeDisplayableOffers.ts
+++ b/src/data/makeDisplayableOffers.ts
@@ -3,10 +3,9 @@ import flatten from "lodash/flatten";
 import { AssetType } from "stellar-base";
 import { Server } from "stellar-sdk";
 
-import { getTokenIdentifier } from "./";
 import { makeDisplayableTrades } from "./makeDisplayableTrades";
 
-import { Offer, Offers, Token, Trade } from "../types";
+import { Account, Offer, Offers, Token, Trade } from "../types";
 
 export type TradeCollection = Server.TradeRecord[];
 
@@ -19,31 +18,28 @@ interface OfferIdMap {
   [offerid: string]: Trade[];
 }
 
-export function makeDisplayableOffers(params: DisplayableOffersParams): Offers {
+export function makeDisplayableOffers(
+  subjectAccount: Account,
+  params: DisplayableOffersParams,
+): Offers {
   const { offers, tradeResponses } = params;
   const trades = flatten(tradeResponses);
 
   // make a map of offerids to the trades involved with them
   // (reminder that each trade has two offerids, one for each side)
-  const offeridsToTradesMap: OfferIdMap = makeDisplayableTrades(trades).reduce(
-    (memo: any, trade: Trade) => {
-      if (trade.senderOfferId) {
-        memo[trade.senderOfferId] = [
-          ...(memo[trade.senderOfferId] || []),
-          trade,
-        ];
-      }
-      if (trade.receiverOfferId) {
-        memo[trade.receiverOfferId] = [
-          ...(memo[trade.receiverOfferId] || []),
-          trade,
-        ];
-      }
+  const offeridsToTradesMap: OfferIdMap = makeDisplayableTrades(
+    subjectAccount,
+    trades,
+  ).reduce((memo: any, trade: Trade) => {
+    if (trade.paymentOfferId) {
+      memo[trade.paymentOfferId] = [
+        ...(memo[trade.paymentOfferId] || []),
+        trade,
+      ];
+    }
 
-      return memo;
-    },
-    {},
-  );
+    return memo;
+  }, {});
 
   return offers.map(
     (offer: Server.OfferRecord): Offer => {
@@ -68,8 +64,6 @@ export function makeDisplayableOffers(params: DisplayableOffersParams): Offers {
               },
       };
 
-      const paymentTokenId: string = getTokenIdentifier(paymentToken);
-
       const incomingToken: Token = {
         type: buying.asset_type as AssetType,
         code: buying.asset_code || "XLM",
@@ -84,12 +78,7 @@ export function makeDisplayableOffers(params: DisplayableOffersParams): Offers {
       const tradePaymentAmount: BigNumber = (
         offeridsToTradesMap[id] || []
       ).reduce((memo: BigNumber, trade: Trade): BigNumber => {
-        const senderTokenId = getTokenIdentifier(trade.senderToken);
-        return memo.plus(
-          senderTokenId === paymentTokenId
-            ? trade.senderAmount
-            : trade.receiverAmount,
-        );
+        return memo.plus(trade.paymentAmount);
       }, new BigNumber(0));
 
       return {

--- a/src/data/makeDisplayableOffers.ts
+++ b/src/data/makeDisplayableOffers.ts
@@ -60,7 +60,7 @@ export function makeDisplayableOffers(
           selling.asset_type === "native"
             ? undefined
             : {
-                publicKey: selling.asset_issuer,
+                key: selling.asset_issuer,
               },
       };
 
@@ -71,7 +71,7 @@ export function makeDisplayableOffers(
           buying.asset_type === "native"
             ? undefined
             : {
-                publicKey: buying.asset_issuer,
+                key: buying.asset_issuer,
               },
       };
 

--- a/src/data/makeDisplayableTrades.test.ts
+++ b/src/data/makeDisplayableTrades.test.ts
@@ -8,6 +8,7 @@ import { makeDisplayableTrades } from "./makeDisplayableTrades";
 
 it("makes trades from real-world examples", () => {
   const trades = makeDisplayableTrades(
+    { publicKey: "PHYREXIA" },
     // @ts-ignore
     parseResponse(TradesResponsePartialFill).records,
   );
@@ -16,29 +17,25 @@ it("makes trades from real-world examples", () => {
     {
       id: "99777639383887873-0",
 
-      senderToken: {
+      paymentToken: {
+        code: "XLM",
+        type: "native",
+      },
+      paymentAmount: new BigNumber("363.0644948"),
+      paymentOfferId: "78448448",
+
+      incomingToken: {
         code: "BAT",
         type: "credit_alphanum4",
         issuer: {
           publicKey: "GBDEVU63Y6NTHJQQZIKVTC23NWLQVP3WJ2RI2OTSJTNYOIGICST6DUXR",
         },
       },
-
-      senderAccount: {
+      incomingAmount: new BigNumber("139.5761839"),
+      incomingAccount: {
         publicKey: "SERRA",
       },
-      senderAmount: new BigNumber("139.5761839"),
-      senderOfferId: "78448401",
-
-      receiverToken: {
-        code: "XLM",
-        type: "native",
-      },
-      receiverAccount: {
-        publicKey: "PHYREXIA",
-      },
-      receiverAmount: new BigNumber("363.0644948"),
-      receiverOfferId: "78448448",
+      incomingOfferId: "78448401",
 
       timestamp: 1554236520,
     },

--- a/src/data/makeDisplayableTrades.ts
+++ b/src/data/makeDisplayableTrades.ts
@@ -2,7 +2,7 @@ import BigNumber from "bignumber.js";
 import { AssetType } from "stellar-base";
 import { Server } from "stellar-sdk";
 
-import { Token, Trade, Trades } from "../types";
+import { Account, Token, Trade, Trades } from "../types";
 
 /*
   {
@@ -44,7 +44,10 @@ import { Token, Trade, Trades } from "../types";
 
 */
 
-export function makeDisplayableTrades(trades: Server.TradeRecord[]): Trades {
+export function makeDisplayableTrades(
+  subjectAccount: Account,
+  trades: Server.TradeRecord[],
+): Trades {
   // make a map of trades to their original offerids
   return trades.map(
     (trade: Server.TradeRecord): Trade => {
@@ -55,6 +58,9 @@ export function makeDisplayableTrades(trades: Server.TradeRecord[]): Trades {
       const counter = {
         publicKey: trade.counter_account,
       };
+
+      const isSubjectBase: boolean =
+        base.publicKey === subjectAccount.publicKey;
 
       const baseToken: Token = {
         type: trade.base_asset_type as AssetType,
@@ -84,23 +90,22 @@ export function makeDisplayableTrades(trades: Server.TradeRecord[]): Trades {
           new Date(trade.ledger_close_time).getTime() / 1000,
         ),
 
-        senderAccount: trade.base_is_seller ? base : counter,
-        senderToken: trade.base_is_seller ? baseToken : counterToken,
-        senderOfferId: trade.base_is_seller
-          ? trade.base_offer_id
-          : trade.counter_offer_id,
-        senderAmount: trade.base_is_seller
+        paymentToken: isSubjectBase ? baseToken : counterToken,
+        paymentAmount: isSubjectBase
           ? new BigNumber(trade.base_amount)
           : new BigNumber(trade.counter_amount),
+        paymentOfferId: isSubjectBase
+          ? trade.base_offer_id
+          : trade.counter_offer_id,
 
-        receiverAccount: !trade.base_is_seller ? base : counter,
-        receiverToken: !trade.base_is_seller ? baseToken : counterToken,
-        receiverOfferId: !trade.base_is_seller
-          ? trade.base_offer_id
-          : trade.counter_offer_id,
-        receiverAmount: !trade.base_is_seller
-          ? new BigNumber(trade.base_amount)
-          : new BigNumber(trade.counter_amount),
+        incomingToken: isSubjectBase ? counterToken : baseToken,
+        incomingAmount: isSubjectBase
+          ? new BigNumber(trade.counter_amount)
+          : new BigNumber(trade.base_amount),
+        incomingAccount: isSubjectBase ? counter : base,
+        incomingOfferId: isSubjectBase
+          ? trade.counter_offer_id
+          : trade.base_offer_id,
       };
     },
   );

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,18 +14,13 @@ export const Constants = {
 /**
  * Data
  */
-import {
-  getBalanceIdentifier,
-  getTokenIdentifier,
-  reframeEffect,
-} from "./data";
+import { getBalanceIdentifier, getTokenIdentifier } from "./data";
 
 import { DataProvider } from "./data/DataProvider";
 
 export const Data = {
   getTokenIdentifier,
   getBalanceIdentifier,
-  reframeEffect,
   DataProvider,
 };
 

--- a/src/types/data.d.ts
+++ b/src/types/data.d.ts
@@ -65,15 +65,15 @@ export interface ReframedEffect {
 
 export interface Trade {
   id: string;
-  senderToken: Token;
-  senderAccount: Account;
-  senderAmount: BigNumber;
-  senderOfferId?: OfferId;
 
-  receiverToken: Token;
-  receiverAccount: Account;
-  receiverAmount: BigNumber;
-  receiverOfferId?: OfferId;
+  paymentToken: Token;
+  paymentAmount: BigNumber;
+  paymentOfferId?: OfferId;
+
+  incomingToken: Token;
+  incomingAccount: Account;
+  incomingAmount: BigNumber;
+  incomingOfferId?: OfferId;
 
   timestamp: number;
 }

--- a/src/types/data.d.ts
+++ b/src/types/data.d.ts
@@ -16,9 +16,9 @@ export interface Account {
 
 export interface Issuer {
   key: string;
-  name: string;
-  url: string;
-  hostName: string;
+  name?: string;
+  url?: string;
+  hostName?: string;
 }
 
 export interface NativeToken {

--- a/src/types/data.d.ts
+++ b/src/types/data.d.ts
@@ -63,6 +63,12 @@ export interface ReframedEffect {
   timestamp: number;
 }
 
+/**
+ * Trades are framed in terms of the account you used to initiate DataProvider.
+ * That means that a trade object will say which token was your "payment" in
+ * the exchange (the token and amount you sent to someone else) and what was
+ * "incoming".
+ */
 export interface Trade {
   id: string;
 


### PR DESCRIPTION
...which was the case except for Trades, so this change reframes trades to be from the POV of the account you init DataProvider with.