### PR TITLE
Add support for pagination

### DIFF
--- a/src/data/DataProvider.ts
+++ b/src/data/DataProvider.ts
@@ -109,10 +109,9 @@ export class DataProvider {
       .limit(params.limit || 10)
       .order(params.order || "desc")
       .cursor(params.cursor || "")
-      .call()
-      .then((data) => data.records);
+      .call();
 
-    return makeDisplayableTransfers({ publicKey: this.accountKey }, transfers);
+    return this._processTransfers(transfers);
   }
 
   /**
@@ -200,6 +199,23 @@ export class DataProvider {
       records: makeDisplayableTrades(
         { publicKey: this.accountKey },
         trades.records,
+      ),
+    };
+  }
+
+  private async _processTransfers(
+    transfers: Server.CollectionPage<
+      | Server.PaymentOperationRecord
+      | Server.CreateAccountOperationRecord
+      | Server.PathPaymentOperationRecord
+    >,
+  ): Promise<Collection<Transfer>> {
+    return {
+      next: () => transfers.next().then(this._processTransfers),
+      prev: () => transfers.prev().then(this._processTransfers),
+      records: makeDisplayableTransfers(
+        { publicKey: this.accountKey },
+        transfers.records,
       ),
     };
   }

--- a/src/types/data.d.ts
+++ b/src/types/data.d.ts
@@ -146,3 +146,15 @@ export interface AccountDetails {
   flags: Horizon.Flags;
   balances: BalanceMap;
 }
+
+export interface CollectionParams {
+  limit?: number;
+  order?: "desc" | "asc";
+  cursor?: string;
+}
+
+export interface Collection<Record> {
+  next: () => Promise<Collection<Record>>;
+  prev: () => Promise<Collection<Record>>;
+  records: Record[];
+}


### PR DESCRIPTION
DataProvider fetch functions now return `{ next: () => {}, prev: () => {}, records: [] }` instead of just records, allowing people an easy way of paginating their results. Fixes #61.