### PR TITLE
Update README documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ keyManager.registerEncrypter(KeyManagerPlugins.ScryptEncrypter);
 // functions to make sure that your plugins meet spec!
 
 this.state.keyManager
-  .storeKeys({
+  .storeKey({
     // The KeyManager takes keys that conform to our Key interface.
     key: {
       type: Constants.KeyType.plaintextKey,


### PR DESCRIPTION
The README is using `storeKeys()` but the method is actually called [`storeKey`](https://github.com/stellar/js-stellar-wallets/blob/aa2ef3c6d86167d21d23ce24e81868a08226b460/src/KeyManager.ts#L110). The confusion was probably due to `storeKeys()` being available on the keyStore object.