### PR TITLE
Get rid of export namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,11 @@ cases (particularly around offer / trade history), properties were renamed for
 clarity.
 
 ```js
-import { Data } from "@stellar/wallet-sdk";
-
-const { getTokenIdentifier, getBalanceIdentifier, DataProvider } = Data;
+import {
+  getTokenIdentifier,
+  getBalanceIdentifier,
+  DataProvider,
+} from "@stellar/wallet-sdk";
 
 // You'll use your DataProvider instance to ask for data from Stellar.
 const dataProvider = new DataProvider({
@@ -64,7 +66,7 @@ never sending sensitive information (the user's key or password) over the wire
 in a raw state.
 
 ```js
-import { KeyManager, KeyManagerPlugins, Constants } from "@stellar/wallet-sdk";
+import { KeyManager, KeyManagerPlugins, KeyType } from "@stellar/wallet-sdk";
 
 // To instantiate a keyManager instance, pass it an object that conforms to
 // the KeyStore interface.
@@ -86,7 +88,7 @@ this.state.keyManager
   .storeKeys({
     // The KeyManager takes keys that conform to our Key interface.
     key: {
-      type: Constants.KeyType.plaintextKey,
+      type: KeyType.plaintextKey,
       publicKey: "<<Insert public key>>",
       privateKey: "<<Insert private key>>",
     },
@@ -108,9 +110,12 @@ Like the rest of the `@steller/wallet-sdk`, the `Transfers` API is meant to
 provide a predictable, easy-to-use interface.
 
 ```js
-import { Transfers, Constants } from "@stellar/wallet-sdk";
-
-const { DepositProvider, WithdrawProvider, getKycUrl } = Transfers;
+import {
+  DepositProvider,
+  WithdrawProvider,
+  getKycUrl,
+  TransferResultType,
+} from "@stellar/wallet-sdk";
 
 const withdrawProvider = new WithdrawProvider("<<Insert transfer server URL>>");
 
@@ -134,11 +139,11 @@ const withdrawResult = await withdrawProvider.withdraw({
 });
 
 switch (withdrawResult.type) {
-  case Constants.TransferResultType.ok:
+  case TransferResultType.ok:
     // The withdraw request succeeded, so submit a payment to the network.
     // makePayment(withdrawResult);
     break;
-  case Constants.TransferResultType.interactiveKyc:
+  case TransferResultType.interactiveKyc:
     if (isBrowser) {
       // To avoid popup blockers, the new window has to be opened directly in
       // response to a user click event, so we need consumers to provide us a
@@ -178,10 +183,10 @@ switch (withdrawResult.type) {
        */
     }
     break;
-  case Constants.TransferResultType.nonInteractiveKyc:
+  case TransferResultType.nonInteractiveKyc:
     // TODO: SEP-12 data submission
     break;
-  case Constants.TransferResultType.kycStatus:
+  case TransferResultType.kycStatus:
     // The KYC information was previously submitted, but hasn't been approved
     // yet. Should show the user the pending status and any supplemental
     // information returned

--- a/documentation/src/App.js
+++ b/documentation/src/App.js
@@ -129,11 +129,11 @@ export const App = () => {
 
   const libraryExports = Object.keys(LIBRARY_EXPORTS).reduce((memo, name) => {
     const item = itemsByName[name];
-    const arm = getArmName(item.sources[0].fileName);
+    const kind = item.kindString;
 
     return {
       ...memo,
-      [arm]: [...(memo[arm] || []), item],
+      [kind]: [...(memo[kind] || []), item],
     };
   }, {});
 

--- a/documentation/src/App.js
+++ b/documentation/src/App.js
@@ -74,6 +74,7 @@ const LIBRARY_EXPORTS = {
   DepositProvider: 1,
   WithdrawProvider: 1,
   getKycUrl: 1,
+  getKeyMetadata: 1,
 };
 
 export const App = () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/wallet-sdk",
-  "version": "0.0.3-rc4",
+  "version": "0.0.3-rc5",
   "description": "Libraries to help you write Stellar-enabled wallets in Javascript",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/playground/src/App.js
+++ b/playground/src/App.js
@@ -2,7 +2,7 @@ import React, { Component } from "react";
 import styled from "styled-components";
 import { GlobalStyle } from "@stellar/elements";
 
-import { Data } from "@stellar/wallet-sdk";
+import { DataProvider } from "@stellar/wallet-sdk";
 
 import AccountDetails from "components/AccountDetails";
 import KeyEntry from "components/KeyEntry";
@@ -22,7 +22,7 @@ class App extends Component {
   };
 
   _setKey = (publicKey) => {
-    const dataProvider = new Data.DataProvider({
+    const dataProvider = new DataProvider({
       serverUrl: "https://horizon.stellar.org",
       accountOrKey: publicKey,
     });

--- a/playground/src/components/KeyEntry.js
+++ b/playground/src/components/KeyEntry.js
@@ -2,7 +2,7 @@ import React, { Component } from "react";
 import StellarSdk from "stellar-sdk";
 import { Input } from "@stellar/elements";
 
-import { KeyManager, KeyManagerPlugins, Constants } from "@stellar/wallet-sdk";
+import { KeyManager, KeyManagerPlugins, KeyType } from "@stellar/wallet-sdk";
 
 export default class KeyEntry extends Component {
   state = {
@@ -34,7 +34,7 @@ export default class KeyEntry extends Component {
       const key = {
         publicKey: account.publicKey(),
         privateKey: account.secret(),
-        type: Constants.KeyType.plaintext,
+        type: KeyType.plaintext,
       };
 
       const password = "fucko";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,28 +1,16 @@
 /**
  * Constants
  */
-import { EffectType } from "./constants/data";
-import { KeyType } from "./constants/keys";
-import { TransferResponseType } from "./constants/transfers";
-
-export const Constants = {
-  EffectType,
-  KeyType,
-  TransferResponseType,
-};
+export { EffectType } from "./constants/data";
+export { KeyType } from "./constants/keys";
+export { TransferResponseType } from "./constants/transfers";
 
 /**
  * Data
  */
-import { getBalanceIdentifier, getTokenIdentifier } from "./data";
+export { getBalanceIdentifier, getTokenIdentifier } from "./data";
 
-import { DataProvider } from "./data/DataProvider";
-
-export const Data = {
-  getTokenIdentifier,
-  getBalanceIdentifier,
-  DataProvider,
-};
+export { DataProvider } from "./data/DataProvider";
 
 /**
  * Key Management
@@ -35,29 +23,14 @@ export { KeyManagerPlugins } from "./KeyManagerPlugins";
  * Plugin Testing
  */
 
-import { testEncrypter, testKeyStore } from "./PluginTesting";
-
-export const PluginTesting = {
-  testEncrypter,
-  testKeyStore,
-};
+export { testEncrypter, testKeyStore } from "./PluginTesting";
 
 /**
  * Transfers
  */
-import { DepositProvider, getKycUrl, WithdrawProvider } from "./transfers";
-
-export const Transfers = {
-  DepositProvider,
-  WithdrawProvider,
-  getKycUrl,
-};
+export { DepositProvider, getKycUrl, WithdrawProvider } from "./transfers";
 
 /**
  * Helpers
  */
-import { getKeyMetadata } from "./helpers/getKeyMetadata";
-
-export const Helpers = {
-  getKeyMetadata,
-};
+export { getKeyMetadata } from "./helpers/getKeyMetadata";


### PR DESCRIPTION
Types weren't transferring over when we would export the arms of the SDK as members of a constant, so see if exporting things directly will fix that issue.