### PR TITLE
Fix a bug with Apay's info

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/wallet-sdk",
-  "version": "0.0.3-rc5",
+  "version": "0.0.3-rc6",
   "description": "Libraries to help you write Stellar-enabled wallets in Javascript",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/fixtures/TransferInfoResponse.ts
+++ b/src/fixtures/TransferInfoResponse.ts
@@ -1,0 +1,126 @@
+export const AnchorUSDTransferInfo = {
+  deposit: {
+    USD: {
+      enabled: true,
+      fee_fixed: 5,
+      fee_percent: 1,
+      min_amount: 15,
+      fields: {
+        email_address: {
+          description: "your email address for transaction status updates",
+        },
+        amount: { description: "amount in USD that you plan to deposit" },
+      },
+    },
+  },
+  withdraw: {
+    USD: {
+      enabled: true,
+      fee_fixed: 5,
+      fee_percent: 2,
+      min_amount: 15,
+      types: {
+        bank_account: {
+          fields: {
+            account: {
+              description:
+                "the stellar account that you will be transferring funds from",
+            },
+            email_address: {
+              description: "your email address for transaction status updates",
+            },
+            amount: {
+              description: "amount in USD that you plan to withdraw",
+              optional: true,
+            },
+          },
+        },
+      },
+    },
+  },
+  transactions: { enabled: false },
+};
+
+export const ApayTransferInfo = {
+  deposit: {
+    BCH: { enabled: true, fee_fixed: 0, min_amount: 0.001 },
+    BTC: { enabled: true, fee_fixed: 0, min_amount: 0.0002 },
+    DASH: { enabled: false, fee_fixed: 0, min_amount: 0.003 },
+    LTC: { enabled: true, fee_fixed: 0, min_amount: 0.01 },
+    ETH: { enabled: true, fee_fixed: 0, min_amount: 0.001 },
+    BAT: { enabled: true, fee_fixed: 0, min_amount: 2 },
+    KIN: { enabled: true, fee_fixed: 0, min_amount: 0 },
+    LINK: { enabled: true, fee_fixed: 0, min_amount: 2 },
+    MTL: { enabled: true, fee_fixed: 0, min_amount: 0.3 },
+    OMG: { enabled: true, fee_fixed: 0, min_amount: 0.1 },
+    REP: { enabled: true, fee_fixed: 0, min_amount: 0.02 },
+    SALT: { enabled: true, fee_fixed: 0, min_amount: 0.5 },
+    ZRX: { enabled: true, fee_fixed: 0, min_amount: 0.5 },
+  },
+  withdraw: {
+    BCH: {
+      enabled: true,
+      fee_fixed: 0.002,
+      min_amount: 0.004,
+      types: { crypto: {} },
+    },
+    BTC: {
+      enabled: true,
+      fee_fixed: 0.0005,
+      min_amount: 0.001,
+      types: { crypto: {} },
+    },
+    DASH: {
+      enabled: false,
+      fee_fixed: 0.006,
+      min_amount: 0.012,
+      types: { crypto: {} },
+    },
+    LTC: {
+      enabled: true,
+      fee_fixed: 0.025,
+      min_amount: 0.05,
+      types: { crypto: {} },
+    },
+    ETH: {
+      enabled: true,
+      fee_fixed: 0.005,
+      min_amount: 0.01,
+      types: { crypto: {} },
+    },
+    BAT: { enabled: true, fee_fixed: 5, min_amount: 10, types: { crypto: {} } },
+    KIN: {
+      enabled: true,
+      fee_fixed: 10000,
+      min_amount: 20000,
+      types: { crypto: {} },
+    },
+    LINK: {
+      enabled: true,
+      fee_fixed: 5,
+      min_amount: 10,
+      types: { crypto: {} },
+    },
+    MTL: {
+      enabled: true,
+      fee_fixed: 0.5,
+      min_amount: 1,
+      types: { crypto: {} },
+    },
+    OMG: {
+      enabled: true,
+      fee_fixed: 0.2,
+      min_amount: 0.4,
+      types: { crypto: {} },
+    },
+    REP: {
+      enabled: true,
+      fee_fixed: 0.05,
+      min_amount: 0.1,
+      types: { crypto: {} },
+    },
+    SALT: { enabled: true, fee_fixed: 1, min_amount: 2, types: { crypto: {} } },
+    ZRX: { enabled: true, fee_fixed: 2, min_amount: 4, types: { crypto: {} } },
+  },
+  transactions: { enabled: false },
+};

--- a/src/transfers/parseInfo.test.ts
+++ b/src/transfers/parseInfo.test.ts
@@ -1,0 +1,14 @@
+import { parseInfo } from "./parseInfo";
+
+import {
+  AnchorUSDTransferInfo,
+  ApayTransferInfo,
+} from "../fixtures/TransferInfoResponse";
+
+it("AnchorUSD: runs without error", () => {
+  parseInfo(AnchorUSDTransferInfo);
+});
+
+it("Apay: runs without error", () => {
+  parseInfo(ApayTransferInfo);
+});

--- a/src/transfers/parseInfo.ts
+++ b/src/transfers/parseInfo.ts
@@ -59,7 +59,7 @@ const parseFee = (
 function parseType([typeName, type]: [string, RawType]) {
   return {
     name: typeName,
-    fields: Object.entries(type.fields).map(parseField),
+    fields: Object.entries(type.fields || {}).map(parseField),
   };
 }
 


### PR DESCRIPTION
- Add parseInfo tests
- Add fixtures based on Apay and AnchorUSD info
- Don't error if info doesn't include field information