### PR TITLE
Allow snake_case deposit params

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/wallet-sdk",
-  "version": "0.0.3-rc8",
+  "version": "0.0.3-rc9",
   "description": "Libraries to help you write Stellar-enabled wallets in Javascript",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/transfers/DepositProvider.ts
+++ b/src/transfers/DepositProvider.ts
@@ -73,10 +73,10 @@ import { TransferProvider } from "./TransferProvider";
 export class DepositProvider extends TransferProvider {
   public async deposit(args: DepositRequest): Promise<TransferResponse> {
     const search = queryString.stringify({
-      asset_code: args.assetCode,
+      asset_code: args.assetCode || args.asset_code,
       account: args.account,
       memo: args.memo,
-      email_address: args.emailAddress,
+      email_address: args.emailAddress || args.email_address,
       type: args.type,
     });
     const response = await fetch(`${this.transferServer}/deposit?${search}`);

--- a/src/types/transfers.ts
+++ b/src/types/transfers.ts
@@ -110,10 +110,12 @@ export interface WithdrawRequest {
 }
 
 export interface DepositRequest {
-  assetCode: string;
+  assetCode?: string;
+  asset_code?: string;
   account: string;
   memo?: Memo;
   emailAddress?: string;
+  email_address?: string;
   type?: string;
 }
 


### PR DESCRIPTION
Transfer servers will report field names as snake_case, so accept snake-case params in DepositProvider.deposit in case apps will use the transfer server's names.