### PR TITLE
Export types in a `Types` namespace

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/wallet-sdk",
-  "version": "0.0.3-rc9",
+  "version": "0.0.3-rc10",
   "description": "Libraries to help you write Stellar-enabled wallets in Javascript",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,9 @@
 /**
  * Types
  */
-export * from "./types";
+import * as Types from "./types";
+
+export { Types };
 
 /**
  * Constants


### PR DESCRIPTION
Makes it easier to distinguish between types and the other non-type exports.