### PR TITLE
getStellarSdkAsset

### DIFF
--- a/documentation/src/App.js
+++ b/documentation/src/App.js
@@ -68,6 +68,7 @@ const LIBRARY_EXPORTS = {
   testKeyStore: 1,
   getTokenIdentifier: 1,
   getBalanceIdentifier: 1,
+  getStellarSdkAsset: 1,
   DataProvider: 1,
   KeyManager: 1,
   KeyManagerPlugins: 1,

--- a/src/data/index.test.ts
+++ b/src/data/index.test.ts
@@ -1,4 +1,5 @@
-import { getTokenIdentifier } from "./";
+import { Asset } from "stellar-sdk";
+import { getStellarSdkAsset, getTokenIdentifier } from "./";
 
 describe("getTokenIdentifier", () => {
   test("native element", () => {
@@ -16,5 +17,29 @@ describe("getTokenIdentifier", () => {
         },
       }),
     ).toEqual("BAT:GBDEVU63Y6NTHJQQZIKVTC23NWLQVP3WJ2RI2OTSJTNYOIGICST6DUXR");
+  });
+});
+
+describe("getStellarSdkAsset", () => {
+  test("native element", () => {
+    expect(getStellarSdkAsset({ type: "native", code: "XLM" })).toEqual(
+      Asset.native(),
+    );
+  });
+  test("normal element", () => {
+    expect(
+      getStellarSdkAsset({
+        code: "BAT",
+        type: "credit_alphanum4",
+        issuer: {
+          key: "GBDEVU63Y6NTHJQQZIKVTC23NWLQVP3WJ2RI2OTSJTNYOIGICST6DUXR",
+        },
+      }),
+    ).toEqual(
+      new Asset(
+        "BAT",
+        "GBDEVU63Y6NTHJQQZIKVTC23NWLQVP3WJ2RI2OTSJTNYOIGICST6DUXR",
+      ),
+    );
   });
 });

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -1,4 +1,4 @@
-import { Horizon } from "stellar-sdk";
+import { Asset, Horizon } from "stellar-sdk";
 
 import { AssetToken, Token } from "../types";
 
@@ -26,4 +26,16 @@ export function getBalanceIdentifier(balance: Horizon.BalanceLine): string {
   }
 
   return `${balance.asset_code}:${balance.asset_issuer}`;
+}
+
+/**
+ * Convert a Wallet-SDK-formatted Token object to a Stellar SDK Asset object.
+ * @returns Returns `${tokenCode}:${issuerKey}`.
+ */
+export function getAsset(token: Token): Asset {
+  if (token.type === "native") {
+    return Asset.native();
+  }
+
+  return new Asset(token.code, (token as AssetToken).issuer.key);
 }

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -32,7 +32,7 @@ export function getBalanceIdentifier(balance: Horizon.BalanceLine): string {
  * Convert a Wallet-SDK-formatted Token object to a Stellar SDK Asset object.
  * @returns Returns `${tokenCode}:${issuerKey}`.
  */
-export function getAsset(token: Token): Asset {
+export function getStellarSdkAsset(token: Token): Asset {
   if (token.type === "native") {
     return Asset.native();
   }

--- a/src/types/data.ts
+++ b/src/types/data.ts
@@ -133,6 +133,7 @@ export interface NativeBalance extends Balance {
 }
 
 export interface BalanceMap {
+  [key: string]: AssetBalance | NativeBalance;
   native: NativeBalance;
 }
 


### PR DESCRIPTION
This SDK has an opinionated shape of an Asset that differs from `stellar-sdk`'s shape, so add a helper that converts from one to the other.