### PR TITLE
Allow arbitrary params for withdraws / deposits

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/wallet-sdk",
-  "version": "0.0.3-rc.11",
+  "version": "0.0.3-rc.12",
   "description": "Libraries to help you write Stellar-enabled wallets in Javascript",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/transfers/DepositProvider.ts
+++ b/src/transfers/DepositProvider.ts
@@ -74,13 +74,14 @@ import { TransferProvider } from "./TransferProvider";
  */
 export class DepositProvider extends TransferProvider {
   public async deposit(args: DepositRequest): Promise<TransferResponse> {
-    const search = queryString.stringify({
-      asset_code: args.assetCode || args.asset_code,
-      account: args.account,
-      memo: args.memo,
-      email_address: args.emailAddress || args.email_address,
-      type: args.type,
-    });
+    // warn about camel-cased props
+    if (args.assetCode && !args.asset_code) {
+      throw new Error(
+        "You provided `assetCode` instead of the correct `asset_code`",
+      );
+    }
+
+    const search = queryString.stringify(args);
     const response = await fetch(`${this.transferServer}/deposit?${search}`);
     const json = (await response.json()) as TransferResponse;
 

--- a/src/transfers/WithdrawProvider.ts
+++ b/src/transfers/WithdrawProvider.ts
@@ -75,14 +75,20 @@ import { TransferProvider } from "./TransferProvider";
  */
 export class WithdrawProvider extends TransferProvider {
   public async withdraw(args: WithdrawRequest): Promise<TransferResponse> {
-    const search = queryString.stringify({
-      type: args.type,
-      asset_code: args.assetCode,
-      dest: args.dest,
-      dest_extra: args.destExtra,
-      account: args.account,
-      memo: args.memo,
-    });
+    // warn about camel-cased props
+    if (args.assetCode && !args.asset_code) {
+      throw new Error(
+        "You provided `assetCode` instead of the correct `asset_code`",
+      );
+    }
+    if (args.destExtra && !args.dest_extra) {
+      throw new Error(
+        "You provided `destExtra` instead of the correct `dest_extra`",
+      );
+    }
+
+    const search = queryString.stringify(args);
+
     const response = await fetch(`${this.transferServer}/withdraw?${search}`);
     const json = (await response.json()) as TransferResponse;
 

--- a/src/types/transfers.ts
+++ b/src/types/transfers.ts
@@ -102,21 +102,19 @@ export interface DepositInfo {
 
 export interface WithdrawRequest {
   type: string;
-  assetCode: string;
+  asset_code: string;
   dest: string;
-  destExtra?: string;
-  account?: string;
-  memo?: Memo;
+  dest_extra: string;
+  account: string;
+  memo: Memo;
+  [key: string]: any;
 }
 
 export interface DepositRequest {
-  assetCode?: string;
-  asset_code?: string;
+  asset_code: string;
   account: string;
-  memo?: Memo;
-  emailAddress?: string;
-  email_address?: string;
-  type?: string;
+  memo: Memo;
+  [key: string]: any;
 }
 
 export interface TransferResponse {

--- a/src/types/transfers.ts
+++ b/src/types/transfers.ts
@@ -105,15 +105,19 @@ export interface WithdrawRequest {
   asset_code: string;
   dest: string;
   dest_extra: string;
-  account: string;
-  memo: Memo;
+  account?: string;
+  memo?: Memo;
+  memo_type?: string;
   [key: string]: any;
 }
 
 export interface DepositRequest {
   asset_code: string;
   account: string;
-  memo: Memo;
+  memo?: Memo;
+  memo_type?: string;
+  email_address?: string;
+  type?: string;
   [key: string]: any;
 }
 


### PR DESCRIPTION
Anchors might ask for various metadata during transfers, so allow them.

Also, only allow snake-cased arguments, and warn if they provide assetCode / destExtra instead.