### PR TITLE
Use snakecase on the other TransferProvider function arguments

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/wallet-sdk",
-  "version": "0.0.3-rc.13",
+  "version": "0.0.3-rc.14",
   "description": "Libraries to help you write Stellar-enabled wallets in Javascript",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/transfers/DepositProvider.test.ts
+++ b/src/transfers/DepositProvider.test.ts
@@ -26,8 +26,8 @@ describe("fetchFinalFee", () => {
 
     expect(
       await provider.fetchFinalFee({
-        supportedAssets: info,
-        assetCode: info.USD.assetCode,
+        supported_assets: info,
+        asset_code: info.USD.assetCode,
         amount: "15",
         type: "",
       }),
@@ -55,8 +55,8 @@ describe("fetchFinalFee", () => {
 
     expect(
       await provider.fetchFinalFee({
-        supportedAssets: info,
-        assetCode: info.EUR.assetCode,
+        supported_assets: info,
+        asset_code: info.EUR.assetCode,
         amount: "10",
         type: "",
       }),

--- a/src/transfers/TransferProvider.ts
+++ b/src/transfers/TransferProvider.ts
@@ -34,24 +34,26 @@ export abstract class TransferProvider {
     | Promise<DepositInfo>;
 
   protected async fetchFinalFee(args: FeeArgs): Promise<number> {
-    const { supportedAssets, assetCode, amount } = args;
+    const { supported_assets, ...rest } = args;
 
-    if (!supportedAssets[assetCode]) {
-      throw new Error(`Can't get fee for an unsupported asset, '${assetCode}`);
+    if (!supported_assets[args.asset_code]) {
+      throw new Error(
+        `Can't get fee for an unsupported asset, '${args.asset_code}`,
+      );
     }
-    const { fee } = supportedAssets[assetCode];
+    const { fee } = supported_assets[args.asset_code];
     switch (fee.type) {
       case "none":
         return 0;
       case "simple":
         const simpleFee = fee as SimpleFee;
         return (
-          ((simpleFee.percent || 0) / 100) * Number(amount) +
+          ((simpleFee.percent || 0) / 100) * Number(args.amount) +
           (simpleFee.fixed || 0)
         );
       case "complex":
         const response = await fetch(
-          `${this.transferServer}/fee?${queryString.stringify(args)}`,
+          `${this.transferServer}/fee?${queryString.stringify(rest)}`,
         );
         const { fee: feeResponse } = await response.json();
         return feeResponse as number;

--- a/src/types/transfers.ts
+++ b/src/types/transfers.ts
@@ -7,8 +7,8 @@ export interface GetKycArgs {
 }
 
 export interface FeeArgs {
-  supportedAssets: WithdrawInfo | DepositInfo;
-  assetCode: string;
+  supported_assets: WithdrawInfo | DepositInfo;
+  asset_code: string;
   amount: string;
   operation: "withdraw" | "deposit";
   type: string;


### PR DESCRIPTION
This keeps it consistent with the deposit / withdraw functions, and also submits the correct `asset_code` var to the /fee endpoint (where previously it was incorrectly sending `assetCode`.)