### PR TITLE
Add support for authorized withdraws / deposits

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/wallet-sdk",
-  "version": "0.0.3-rc.13",
+  "version": "0.0.3-rc.14",
   "description": "Libraries to help you write Stellar-enabled wallets in Javascript",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "@types/jest": "^24.0.11",
     "@types/stellar-base": "^0.10.2",
     "bignumber.js": "^8.1.1",
+    "change-case": "^3.1.0",
     "lodash": "^4.17.14",
     "query-string": "^6.4.2",
     "scrypt-async": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/wallet-sdk",
-  "version": "0.0.3-rc.14",
+  "version": "0.0.3-rc.15",
   "description": "Libraries to help you write Stellar-enabled wallets in Javascript",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/transfers/DepositProvider.test.ts
+++ b/src/transfers/DepositProvider.test.ts
@@ -26,8 +26,8 @@ describe("fetchFinalFee", () => {
 
     expect(
       await provider.fetchFinalFee({
-        supportedAssets: info,
-        assetCode: info.USD.assetCode,
+        supported_assets: info,
+        asset_code: info.USD.assetCode,
         amount: "15",
         type: "",
       }),
@@ -55,8 +55,8 @@ describe("fetchFinalFee", () => {
 
     expect(
       await provider.fetchFinalFee({
-        supportedAssets: info,
-        assetCode: info.EUR.assetCode,
+        supported_assets: info,
+        asset_code: info.EUR.assetCode,
         amount: "10",
         type: "",
       }),

--- a/src/transfers/DepositProvider.test.ts
+++ b/src/transfers/DepositProvider.test.ts
@@ -2,6 +2,37 @@ import { DepositProvider } from "./DepositProvider";
 
 import { DepositInfo } from "../types";
 
+describe("makeSnakeCase", () => {
+  test("changes camelcase things", () => {
+    const provider = new DepositProvider("test");
+    const req = {
+      type: "type",
+      assetCode: "assetCode",
+      dest: "dest",
+      destExtra: "destExtra",
+      account: "account",
+    };
+    expect(provider.makeSnakeCase(req)).toEqual({
+      type: "type",
+      asset_code: "assetCode",
+      dest: "dest",
+      dest_extra: "destExtra",
+      account: "account",
+    });
+  });
+  test("doesn't change snakeCase stuff", () => {
+    const provider = new DepositProvider("test");
+    const req = {
+      type: "type",
+      asset_code: "assetCode",
+      dest: "dest",
+      dest_extra: "destExtra",
+      account: "account",
+    };
+    expect(provider.makeSnakeCase(req)).toEqual(req);
+  });
+});
+
 describe("fetchFinalFee", () => {
   test("AnchorUSD", async () => {
     const info: DepositInfo = {
@@ -29,7 +60,7 @@ describe("fetchFinalFee", () => {
 
     expect(
       await provider.fetchFinalFee({
-        asset_code: info.USD.assetCode,
+        assetCode: info.USD.assetCode,
         amount: "15",
         type: "",
       }),
@@ -59,7 +90,7 @@ describe("fetchFinalFee", () => {
 
     expect(
       await provider.fetchFinalFee({
-        asset_code: info.EUR.assetCode,
+        assetCode: info.EUR.assetCode,
         amount: "10",
         type: "",
       }),

--- a/src/transfers/DepositProvider.test.ts
+++ b/src/transfers/DepositProvider.test.ts
@@ -24,9 +24,11 @@ describe("fetchFinalFee", () => {
 
     const provider = new DepositProvider("test");
 
+    // manually set info
+    provider.info = { deposit: info, withdraw: {} };
+
     expect(
       await provider.fetchFinalFee({
-        supported_assets: info,
         asset_code: info.USD.assetCode,
         amount: "15",
         type: "",
@@ -53,9 +55,10 @@ describe("fetchFinalFee", () => {
 
     const provider = new DepositProvider("test");
 
+    provider.info = { deposit: info, withdraw: {} };
+
     expect(
       await provider.fetchFinalFee({
-        supported_assets: info,
         asset_code: info.EUR.assetCode,
         amount: "10",
         type: "",

--- a/src/transfers/DepositProvider.ts
+++ b/src/transfers/DepositProvider.ts
@@ -78,21 +78,14 @@ export class DepositProvider extends TransferProvider {
       throw new Error("Run fetchSupportedAssets before running deposit!");
     }
 
-    // warn about camel-cased props
-    if (args.assetCode && !args.asset_code) {
-      throw new Error(
-        "You provided `assetCode` instead of the correct `asset_code`",
-      );
-    }
-
-    const search = queryString.stringify(args);
-    const isAuthRequired = this.info.withdraw[args.asset_code]
+    const search = queryString.stringify(this.makeSnakeCase(args));
+    const isAuthRequired = this.info.withdraw[args.assetCode]
       .authenticationRequired;
 
     if (isAuthRequired && !this.bearerToken) {
       throw new Error(
         `${
-          args.asset_code
+          args.assetCode
         } requires authentication, please authorize with setBearerToken.`,
       );
     }

--- a/src/transfers/TransferProvider.ts
+++ b/src/transfers/TransferProvider.ts
@@ -17,6 +17,7 @@ import { parseInfo } from "./parseInfo";
  */
 export abstract class TransferProvider {
   public transferServer: string;
+  public bearerToken?: string;
 
   constructor(transferServer: string) {
     this.transferServer = transferServer;
@@ -25,8 +26,21 @@ export abstract class TransferProvider {
   protected async fetchInfo(): Promise<Info> {
     const response = await fetch(`${this.transferServer}/info`);
     const rawInfo = (await response.json()) as RawInfoResponse;
-
     return parseInfo(rawInfo);
+  }
+
+  protected getHeaders(): Headers {
+    return new Headers(
+      this.bearerToken
+        ? {
+            Authorization: `Bearer ${this.bearerToken}`,
+          }
+        : {},
+    );
+  }
+
+  public setBearerToken(token: string) {
+    this.bearerToken = token;
   }
 
   public abstract fetchSupportedAssets():

--- a/src/transfers/TransferProvider.ts
+++ b/src/transfers/TransferProvider.ts
@@ -34,24 +34,26 @@ export abstract class TransferProvider {
     | Promise<DepositInfo>;
 
   protected async fetchFinalFee(args: FeeArgs): Promise<number> {
-    const { supportedAssets, assetCode, amount } = args;
+    const { supported_assets, ...rest } = args;
 
-    if (!supportedAssets[assetCode]) {
-      throw new Error(`Can't get fee for an unsupported asset, '${assetCode}`);
+    if (!supported_assets[args.asset_code]) {
+      throw new Error(
+        `Can't get fee for an unsupported asset, '${args.asset_code}`,
+      );
     }
-    const { fee } = supportedAssets[assetCode];
+    const { fee } = supported_assets[args.asset_code];
     switch (fee.type) {
       case "none":
         return 0;
       case "simple":
         const simpleFee = fee as SimpleFee;
         return (
-          ((simpleFee.percent || 0) / 100) * Number(amount) +
+          ((simpleFee.percent || 0) / 100) * Number(args.amount) +
           (simpleFee.fixed || 0)
         );
       case "complex":
         const response = await fetch(
-          `${this.transferServer}/fee?${queryString.stringify(args)}`,
+          `${this.transferServer}/fee?${queryString.stringify(rest)}`,
         );
         const { fee: feeResponse } = await response.json();
         return feeResponse as number;

--- a/src/transfers/TransferProvider.ts
+++ b/src/transfers/TransferProvider.ts
@@ -1,3 +1,4 @@
+import changeCase from "change-case";
 import queryString from "query-string";
 
 import {
@@ -42,6 +43,16 @@ export abstract class TransferProvider {
     );
   }
 
+  public makeSnakeCase(args: any) {
+    return Object.keys(args).reduce(
+      (memo: object, name: string) => ({
+        ...memo,
+        [changeCase.snakeCase(name)]: args[name],
+      }),
+      {},
+    );
+  }
+
   public setBearerToken(token: string) {
     this.bearerToken = token;
   }
@@ -55,11 +66,11 @@ export abstract class TransferProvider {
       throw new Error("Run fetchSupportedAssets before running fetchFinalFee!");
     }
 
-    const assetInfo = this.info[args.operation][args.asset_code];
+    const assetInfo = this.info[args.operation][args.assetCode];
 
     if (!assetInfo) {
       throw new Error(
-        `Can't get fee for an unsupported asset, '${args.asset_code}`,
+        `Can't get fee for an unsupported asset, '${args.assetCode}`,
       );
     }
     const { fee } = assetInfo;
@@ -74,7 +85,9 @@ export abstract class TransferProvider {
         );
       case "complex":
         const response = await fetch(
-          `${this.transferServer}/fee?${queryString.stringify(args as any)}`,
+          `${this.transferServer}/fee?${queryString.stringify(
+            this.makeSnakeCase(args as any),
+          )}`,
         );
         const { fee: feeResponse } = await response.json();
         return feeResponse as number;

--- a/src/transfers/WithdrawProvider.ts
+++ b/src/transfers/WithdrawProvider.ts
@@ -74,31 +74,25 @@ import { TransferProvider } from "./TransferProvider";
  * serverside/native apps, `getKycUrl`.
  */
 export class WithdrawProvider extends TransferProvider {
+  /**
+   * Make a withdraw request.
+   *
+   * Note that all arguments must be in camelCase, even though they're sent to
+   * the server in snake_case!
+   */
   public async withdraw(args: WithdrawRequest): Promise<TransferResponse> {
     if (!this.info || !this.info.withdraw) {
       throw new Error("Run fetchSupportedAssets before running withdraw!");
     }
 
-    // warn about camel-cased props
-    if (args.assetCode && !args.asset_code) {
-      throw new Error(
-        "You provided `assetCode` instead of the correct `asset_code`",
-      );
-    }
-    if (args.destExtra && !args.dest_extra) {
-      throw new Error(
-        "You provided `destExtra` instead of the correct `dest_extra`",
-      );
-    }
-
-    const search = queryString.stringify(args);
-    const isAuthRequired = this.info.withdraw[args.asset_code]
+    const search = queryString.stringify(this.makeSnakeCase(args));
+    const isAuthRequired = this.info.withdraw[args.assetCode]
       .authenticationRequired;
 
     if (isAuthRequired && !this.bearerToken) {
       throw new Error(
         `${
-          args.asset_code
+          args.assetCode
         } requires authentication, please authorize with setBearerToken.`,
       );
     }

--- a/src/transfers/parseInfo.ts
+++ b/src/transfers/parseInfo.ts
@@ -82,6 +82,7 @@ export function parseWithdraw(info: RawInfoResponse): WithdrawInfo {
         fee,
         minAmount: entry.min_amount,
         maxAmount: entry.max_amount,
+        authenticationRequired: !!entry.authentication_required,
         types: Object.entries(entry.types || {}).map(parseType),
       };
       return accum;
@@ -100,6 +101,7 @@ export function parseDeposit(info: RawInfoResponse): DepositInfo {
         fee,
         minAmount: entry.min_amount,
         maxAmount: entry.max_amount,
+        authenticationRequired: !!entry.authentication_required,
         fields: Object.entries(entry.fields || {}).map(parseField),
       };
       return accum;

--- a/src/types/transfers.ts
+++ b/src/types/transfers.ts
@@ -22,6 +22,7 @@ export interface RawInfoResponse {
       fee_percent: number;
       min_amount: number;
       max_amount: number;
+      authentication_required?: boolean;
       types?: {
         [type: string]: RawType;
       };
@@ -34,6 +35,7 @@ export interface RawInfoResponse {
       fee_percent: number;
       min_amount: number;
       max_amount: number;
+      authentication_required?: boolean;
       fields?: {
         [field: string]: RawField;
       };
@@ -82,6 +84,7 @@ export interface WithdrawAssetInfo {
   minAmount: number;
   maxAmount: number;
   types: WithdrawType[];
+  authenticationRequired?: boolean;
 }
 
 export interface WithdrawInfo {
@@ -94,6 +97,7 @@ export interface DepositAssetInfo {
   minAmount: number;
   maxAmount?: number;
   fields: Field[];
+  authenticationRequired?: boolean;
 }
 
 export interface DepositInfo {

--- a/src/types/transfers.ts
+++ b/src/types/transfers.ts
@@ -7,7 +7,7 @@ export interface GetKycArgs {
 }
 
 export interface FeeArgs {
-  asset_code: string;
+  assetCode: string;
   amount: string;
   operation: "withdraw" | "deposit";
   type: string;
@@ -105,21 +105,21 @@ export interface DepositInfo {
 
 export interface WithdrawRequest {
   type: string;
-  asset_code: string;
+  assetCode: string;
   dest: string;
-  dest_extra: string;
+  destExtra: string;
   account?: string;
   memo?: Memo;
-  memo_type?: string;
+  memoType?: string;
   [key: string]: any;
 }
 
 export interface DepositRequest {
-  asset_code: string;
+  assetCode: string;
   account: string;
   memo?: Memo;
-  memo_type?: string;
-  email_address?: string;
+  memoType?: string;
+  emailAddress?: string;
   type?: string;
   [key: string]: any;
 }

--- a/src/types/transfers.ts
+++ b/src/types/transfers.ts
@@ -7,7 +7,6 @@ export interface GetKycArgs {
 }
 
 export interface FeeArgs {
-  supported_assets: WithdrawInfo | DepositInfo;
   asset_code: string;
   amount: string;
   operation: "withdraw" | "deposit";

--- a/src/types/transfers.ts
+++ b/src/types/transfers.ts
@@ -7,8 +7,8 @@ export interface GetKycArgs {
 }
 
 export interface FeeArgs {
-  supportedAssets: WithdrawInfo | DepositInfo;
-  assetCode: string;
+  supported_assets: WithdrawInfo | DepositInfo;
+  asset_code: string;
   amount: string;
   operation: "withdraw" | "deposit";
   type: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1508,6 +1508,14 @@ callsites@^3.0.0:
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.0.0.tgz#fb7eb569b72ad7a45812f93fd9430a3e410b3dd3"
   integrity sha512-tWnkwu9YEq2uzlBDI4RcLn8jrFvF9AOi8PxDNU3hZZjJcjkcRAq3vCI+vZcg1SuxISDYe86k9VZFwAxDiJGoAw==
 
+camel-case@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/camel-case/-/camel-case-3.0.0.tgz#ca3c3688a4e9cf3a4cda777dc4dcbc713249cf73"
+  integrity sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=
+  dependencies:
+    no-case "^2.2.0"
+    upper-case "^1.1.1"
+
 camelcase@^5.0.0:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
@@ -1549,6 +1557,30 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.3.0, chalk@^2.3.1, chalk@^2.4.1, chalk@^2.4
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
+
+change-case@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/change-case/-/change-case-3.1.0.tgz#0e611b7edc9952df2e8513b27b42de72647dd17e"
+  integrity sha512-2AZp7uJZbYEzRPsFoa+ijKdvp9zsrnnt6+yFokfwEpeJm0xuJDVoxiRCAaTzyJND8GJkofo2IcKWaUZ/OECVzw==
+  dependencies:
+    camel-case "^3.0.0"
+    constant-case "^2.0.0"
+    dot-case "^2.1.0"
+    header-case "^1.0.0"
+    is-lower-case "^1.1.0"
+    is-upper-case "^1.1.0"
+    lower-case "^1.1.1"
+    lower-case-first "^1.0.0"
+    no-case "^2.3.2"
+    param-case "^2.1.0"
+    pascal-case "^2.0.0"
+    path-case "^2.1.0"
+    sentence-case "^2.1.0"
+    snake-case "^2.1.0"
+    swap-case "^1.1.0"
+    title-case "^2.1.0"
+    upper-case "^1.1.1"
+    upper-case-first "^1.1.0"
 
 chownr@^1.1.1:
   version "1.1.1"
@@ -1655,6 +1687,14 @@ console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
   integrity sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=
+
+constant-case@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/constant-case/-/constant-case-2.0.0.tgz#4175764d389d3fa9c8ecd29186ed6005243b6a46"
+  integrity sha1-QXV2TTidP6nI7NKRhu1gBSQ7akY=
+  dependencies:
+    snake-case "^2.1.0"
+    upper-case "^1.1.1"
 
 convert-source-map@^1.1.0, convert-source-map@^1.4.0:
   version "1.6.0"
@@ -1915,6 +1955,13 @@ domexception@^1.0.1:
   integrity sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==
   dependencies:
     webidl-conversions "^4.0.2"
+
+dot-case@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/dot-case/-/dot-case-2.1.1.tgz#34dcf37f50a8e93c2b3bca8bb7fb9155c7da3bee"
+  integrity sha1-NNzzf1Co6TwrO8qLt/uRVcfaO+4=
+  dependencies:
+    no-case "^2.2.0"
 
 duplexer@~0.1.1:
   version "0.1.1"
@@ -2479,6 +2526,14 @@ has@^1.0.1, has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
+header-case@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/header-case/-/header-case-1.0.1.tgz#9535973197c144b09613cd65d317ef19963bd02d"
+  integrity sha1-lTWXMZfBRLCWE81l0xfvGZY70C0=
+  dependencies:
+    no-case "^2.2.0"
+    upper-case "^1.1.3"
+
 highlight.js@^9.13.1:
   version "9.15.8"
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.15.8.tgz#f344fda123f36f1a65490e932cf90569e4999971"
@@ -2730,6 +2785,13 @@ is-glob@^4.0.0:
   dependencies:
     is-extglob "^2.1.1"
 
+is-lower-case@^1.1.0:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/is-lower-case/-/is-lower-case-1.1.3.tgz#7e147be4768dc466db3bfb21cc60b31e6ad69393"
+  integrity sha1-fhR75HaNxGbbO/shzGCzHmrWk5M=
+  dependencies:
+    lower-case "^1.1.0"
+
 is-number@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-3.0.0.tgz#24fd6201a4782cf50561c810276afc7d12d71195"
@@ -2808,6 +2870,13 @@ is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
   integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
+
+is-upper-case@^1.1.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/is-upper-case/-/is-upper-case-1.1.2.tgz#8d0b1fa7e7933a1e58483600ec7d9661cbaf756f"
+  integrity sha1-jQsfp+eTOh5YSDYA7H2WYcuvdW8=
+  dependencies:
+    upper-case "^1.1.0"
 
 is-windows@^1.0.2:
   version "1.0.2"
@@ -3604,6 +3673,18 @@ loose-envify@^1.0.0:
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
 
+lower-case-first@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/lower-case-first/-/lower-case-first-1.0.2.tgz#e5da7c26f29a7073be02d52bac9980e5922adfa1"
+  integrity sha1-5dp8JvKacHO+AtUrrJmA5ZIq36E=
+  dependencies:
+    lower-case "^1.1.2"
+
+lower-case@^1.1.0, lower-case@^1.1.1, lower-case@^1.1.2:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/lower-case/-/lower-case-1.1.4.tgz#9a2cabd1b9e8e0ae993a4bf7d5875c39c42e8eac"
+  integrity sha1-miyr0bno4K6ZOkv31YdcOcQujqw=
+
 lru-cache@^4.0.1:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.5.tgz#8bbe50ea85bed59bc9e33dcab8235ee9bcf443cd"
@@ -3842,6 +3923,13 @@ nise@^1.4.10:
     just-extend "^4.0.2"
     lolex "^2.3.2"
     path-to-regexp "^1.7.0"
+
+no-case@^2.2.0, no-case@^2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/no-case/-/no-case-2.3.2.tgz#60b813396be39b3f1288a4c1ed5d1e7d28b464ac"
+  integrity sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==
+  dependencies:
+    lower-case "^1.1.1"
 
 node-cleanup@^2.1.2:
   version "2.1.2"
@@ -4148,6 +4236,13 @@ p-try@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
+param-case@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/param-case/-/param-case-2.1.1.tgz#df94fd8cf6531ecf75e6bef9a0858fbc72be2247"
+  integrity sha1-35T9jPZTHs915r75oIWPvHK+Ikc=
+  dependencies:
+    no-case "^2.2.0"
+
 parse-json@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-4.0.0.tgz#be35f5425be1f7f6c747184f98a788cb99477ee0"
@@ -4161,10 +4256,25 @@ parse5@4.0.0:
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-4.0.0.tgz#6d78656e3da8d78b4ec0b906f7c08ef1dfe3f608"
   integrity sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==
 
+pascal-case@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/pascal-case/-/pascal-case-2.0.1.tgz#2d578d3455f660da65eca18ef95b4e0de912761e"
+  integrity sha1-LVeNNFX2YNpl7KGO+VtODekSdh4=
+  dependencies:
+    camel-case "^3.0.0"
+    upper-case-first "^1.1.0"
+
 pascalcase@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
   integrity sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=
+
+path-case@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/path-case/-/path-case-2.1.1.tgz#94b8037c372d3fe2906e465bb45e25d226e8eea5"
+  integrity sha1-lLgDfDctP+KQbkZbtF4l0ibo7qU=
+  dependencies:
+    no-case "^2.2.0"
 
 path-exists@^3.0.0:
   version "3.0.0"
@@ -4706,6 +4816,14 @@ semver@^5.4.1, semver@^5.6.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
   integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==
 
+sentence-case@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/sentence-case/-/sentence-case-2.1.1.tgz#1f6e2dda39c168bf92d13f86d4a918933f667ed4"
+  integrity sha1-H24t2jnBaL+S0T+G1KkYkz9mftQ=
+  dependencies:
+    no-case "^2.2.0"
+    upper-case-first "^1.1.2"
+
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
@@ -4794,6 +4912,13 @@ slice-ansi@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-0.0.4.tgz#edbf8903f66f7ce2f8eafd6ceed65e264c831b35"
   integrity sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=
+
+snake-case@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/snake-case/-/snake-case-2.1.0.tgz#41bdb1b73f30ec66a04d4e2cad1b76387d4d6d9f"
+  integrity sha1-Qb2xtz8w7GagTU4srRt2OH1NbZ8=
+  dependencies:
+    no-case "^2.2.0"
 
 snapdragon-node@^2.0.1:
   version "2.1.1"
@@ -5109,6 +5234,14 @@ supports-color@^6.0.0, supports-color@^6.1.0:
   dependencies:
     has-flag "^3.0.0"
 
+swap-case@^1.1.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/swap-case/-/swap-case-1.1.2.tgz#c39203a4587385fad3c850a0bd1bcafa081974e3"
+  integrity sha1-w5IDpFhzhfrTyFCgvRvK+ggZdOM=
+  dependencies:
+    lower-case "^1.1.1"
+    upper-case "^1.1.1"
+
 symbol-observable@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
@@ -5156,6 +5289,14 @@ through@2, through@~2.3, through@~2.3.1:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
+
+title-case@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/title-case/-/title-case-2.1.1.tgz#3e127216da58d2bc5becf137ab91dae3a7cd8faa"
+  integrity sha1-PhJyFtpY0rxb7PE3q5Ha46fNj6o=
+  dependencies:
+    no-case "^2.2.0"
+    upper-case "^1.0.3"
 
 tmpl@1.0.x:
   version "1.0.4"
@@ -5402,6 +5543,18 @@ unset-value@^1.0.0:
   dependencies:
     has-value "^0.3.1"
     isobject "^3.0.0"
+
+upper-case-first@^1.1.0, upper-case-first@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/upper-case-first/-/upper-case-first-1.1.2.tgz#5d79bedcff14419518fd2edb0a0507c9b6859115"
+  integrity sha1-XXm+3P8UQZUY/S7bCgUHybaFkRU=
+  dependencies:
+    upper-case "^1.1.1"
+
+upper-case@^1.0.3, upper-case@^1.1.0, upper-case@^1.1.1, upper-case@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/upper-case/-/upper-case-1.1.3.tgz#f6b4501c2ec4cdd26ba78be7222961de77621598"
+  integrity sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg=
 
 uri-js@^4.2.2:
   version "4.2.2"


### PR DESCRIPTION
Addresses #72, though this isn't quite tested yet.

- Provider classes now track info locally. So you don't have to pass `supportedAssets` to `fetchFinalFee`, but you do have to call `fetchSupportedAssets` ASAP.
- Switch back to all camelCase function inputs, since the Transfer stuff already outputs stuff in camelCase. Unfortunately, it means that devs might have to convert names from `info.fields` from snake_case to camelCase (and I think we should stop short of rewriting those values). But I think, better to be consistent and be clear about that consistency than to be correct but confusing.
- Add a function to set bearer tokens.
- Set Authorization headers when deposit/withdrawing an asset that's auth-required.
