### PR TITLE
Support fetching / watching unfunded accounts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/wallet-sdk",
-  "version": "0.0.3-rc.17",
+  "version": "0.0.3-rc.18",
   "description": "Libraries to help you write Stellar-enabled wallets in Javascript",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/playground/src/App.js
+++ b/playground/src/App.js
@@ -22,6 +22,7 @@ const El = styled.div`
 class App extends Component {
   state = {
     dataProvider: null,
+    isTestnet: false,
   };
 
   componentDidMount() {
@@ -29,9 +30,11 @@ class App extends Component {
     window.WalletSdk = WalletSdk;
   }
 
-  _setKey = (publicKey) => {
+  _setKey = (publicKey, isTestnet) => {
     const dataProvider = new WalletSdk.DataProvider({
-      serverUrl: "https://horizon.stellar.org",
+      serverUrl: isTestnet
+        ? "https://horizon-testnet.stellar.org/"
+        : "https://horizon.stellar.org",
       accountOrKey: publicKey,
     });
 

--- a/playground/src/components/AccountDetails.js
+++ b/playground/src/components/AccountDetails.js
@@ -6,6 +6,7 @@ class AccountDetails extends Component {
     err: null,
     updateTimes: [],
     streamEnder: null,
+    isAccountFunded: null,
   };
 
   componentDidMount() {
@@ -41,11 +42,17 @@ class AccountDetails extends Component {
       err: null,
       updateTimes: [],
       streamEnder: null,
+      isAccountFunded: false,
     });
+
+    dataProvider
+      .isAccountFunded()
+      .then((isFunded) => this.setState({ isFunded }));
 
     const streamEnder = dataProvider.watchAccountDetails({
       onMessage: (accountDetails) => {
         this.setState({
+          isAccountFunded: true,
           accountDetails,
           updateTimes: [...this.state.updateTimes, new Date()],
         });
@@ -63,17 +70,25 @@ class AccountDetails extends Component {
   };
 
   render() {
-    const { accountDetails, err, updateTimes } = this.state;
+    const { accountDetails, err, updateTimes, isAccountFunded } = this.state;
     return (
       <div>
         <h2>Account Details</h2>
-        <ul>
-          {updateTimes.map((time) => (
-            <li key={time.toString()}>{time.toString()}</li>
-          ))}
-        </ul>
 
-        {accountDetails && <pre>{JSON.stringify(accountDetails, null, 2)}</pre>}
+        {!isAccountFunded && <p>Account isn't funded yet.</p>}
+        {isAccountFunded && (
+          <>
+            <ul>
+              {updateTimes.map((time) => (
+                <li key={time.toString()}>{time.toString()}</li>
+              ))}
+            </ul>
+            {accountDetails && (
+              <pre>{JSON.stringify(accountDetails, null, 2)}</pre>
+            )}
+          </>
+        )}
+
         {err && <p>Error: {err.toString()}</p>}
       </div>
     );

--- a/playground/src/components/KeyEntry.js
+++ b/playground/src/components/KeyEntry.js
@@ -1,6 +1,6 @@
 import React, { Component } from "react";
 import StellarSdk from "stellar-sdk";
-import { Input } from "@stellar/elements";
+import { Input, Checkbox } from "@stellar/elements";
 
 import { KeyManager, KeyManagerPlugins, KeyType } from "@stellar/wallet-sdk";
 
@@ -14,6 +14,7 @@ export default class KeyEntry extends Component {
     authServer: "",
     authToken: null,
     authTokenError: null,
+    isTestnet: false,
   };
 
   componentDidMount() {
@@ -48,7 +49,7 @@ export default class KeyEntry extends Component {
 
       this.setState({ key: keyMetadata });
 
-      this.props.onSetKey(keyMetadata.publicKey);
+      this.props.onSetKey(keyMetadata.publicKey, this.state.isTestnet);
     } catch (e) {
       this.setState({ error: e.toString() });
     }
@@ -80,6 +81,7 @@ export default class KeyEntry extends Component {
       keyInput,
       password,
       error,
+      isTestnet,
     } = this.state;
 
     const localKey = localStorage.getItem("key");
@@ -87,6 +89,7 @@ export default class KeyEntry extends Component {
     if (key) {
       return (
         <>
+          {isTestnet ? <p>Testnet</p> : <p>Mainnet</p>}
           <p>Password: {password}</p>
 
           <pre>{JSON.stringify(key, null, 2)}</pre>
@@ -151,6 +154,12 @@ export default class KeyEntry extends Component {
             onChange={(ev) => this.setState({ password: ev.target.value })}
           />
         </label>
+
+        <Checkbox
+          label="Use testnet"
+          checked={isTestnet}
+          onChange={() => this.setState({ isTestnet: !isTestnet })}
+        />
 
         {error && <p style={{ color: "red" }}>Sad error: {error}</p>}
 

--- a/playground/src/components/KeyEntry.js
+++ b/playground/src/components/KeyEntry.js
@@ -32,15 +32,21 @@ export default class KeyEntry extends Component {
   }
 
   _setKey = async (privateKey, password) => {
+    let key;
+
     try {
       const account = StellarSdk.Keypair.fromSecret(privateKey);
-
-      const key = {
+      key = {
         publicKey: account.publicKey(),
         privateKey: account.secret(),
         type: KeyType.plaintextKey,
       };
+    } catch (e) {
+      this.setState({ error: "That wasn't a valid secret key." });
+      return;
+    }
 
+    try {
       const keyMetadata = await this.state.keyManager.storeKey({
         key,
         password,

--- a/src/data/DataProvider.test.ts
+++ b/src/data/DataProvider.test.ts
@@ -35,9 +35,7 @@ describe("Account validation", () => {
         serverUrl: "https://horizon.stellar.org",
       });
     } catch (e) {
-      console.log("error: ", e);
       expect(e).toBeTruthy();
-      expect(e.isUnfunded).toBeFalsy();
     }
     expect(provider).not.toBeInstanceOf(DataProvider);
   });

--- a/src/data/DataProvider.test.ts
+++ b/src/data/DataProvider.test.ts
@@ -1,0 +1,44 @@
+import { generatePlaintextKey } from "../fixtures/keys";
+import { DataProvider } from "./DataProvider";
+
+describe("Account validation", () => {
+  test("works with real public keys", () => {
+    try {
+      const provider = new DataProvider({
+        accountOrKey:
+          "GDZBHQFIHLVDF6GCRV5DT2STB6ZXAJR3JFGZNXNPLB35TH5GNMUVIAQP",
+        serverUrl: "https://horizon.stellar.org",
+      });
+      expect(provider).toBeInstanceOf(DataProvider);
+    } catch (e) {
+      expect(e).toBeUndefined();
+    }
+  });
+
+  test("works with real typed Keys", () => {
+    try {
+      const provider = new DataProvider({
+        accountOrKey: generatePlaintextKey(),
+        serverUrl: "https://horizon.stellar.org",
+      });
+      expect(provider).toBeInstanceOf(DataProvider);
+    } catch (e) {
+      expect(e).toBeUndefined();
+    }
+  });
+
+  test("Throw with bad key", () => {
+    let provider;
+    try {
+      provider = new DataProvider({
+        accountOrKey: "I am not a stupid key you dumbdumb",
+        serverUrl: "https://horizon.stellar.org",
+      });
+    } catch (e) {
+      console.log("error: ", e);
+      expect(e).toBeTruthy();
+      expect(e.isUnfunded).toBeFalsy();
+    }
+    expect(provider).not.toBeInstanceOf(DataProvider);
+  });
+});

--- a/src/data/DataProvider.ts
+++ b/src/data/DataProvider.ts
@@ -49,6 +49,14 @@ export class DataProvider {
       ? params.accountOrKey.publicKey
       : params.accountOrKey;
 
+    if (!accountKey) {
+      throw new Error("No account key provided.");
+    }
+
+    if (!params.serverUrl) {
+      throw new Error("No server url provided.");
+    }
+
     // make sure the account key is a real account
     try {
       Keypair.fromPublicKey(accountKey);

--- a/src/data/DataProvider.ts
+++ b/src/data/DataProvider.ts
@@ -86,6 +86,18 @@ export class DataProvider {
   }
 
   /**
+   * Check if the current account is funded or not.
+   */
+  public async isAccountFunded(): Promise<boolean> {
+    try {
+      await this.fetchAccountDetails();
+      return true;
+    } catch (e) {
+      return !!e.isUnfunded;
+    }
+  }
+
+  /**
    * Fetch outstanding offers.
    */
   public async fetchOpenOffers(

--- a/src/data/DataProvider.ts
+++ b/src/data/DataProvider.ts
@@ -1,6 +1,6 @@
 // @ts-ignore
 import debounce from "lodash/debounce";
-import { Server, ServerApi, StrKey } from "stellar-sdk";
+import { Keypair, Server, ServerApi, StrKey } from "stellar-sdk";
 
 import {
   Account,
@@ -45,11 +45,20 @@ export class DataProvider {
   private callbacks: CallbacksObject;
 
   constructor(params: DataProviderParams) {
-    this.serverUrl = params.serverUrl;
-    this.accountKey = isAccount(params.accountOrKey)
+    const accountKey = isAccount(params.accountOrKey)
       ? params.accountOrKey.publicKey
       : params.accountOrKey;
+
+    // make sure the account key is a real account
+    try {
+      Keypair.fromPublicKey(accountKey);
+    } catch (e) {
+      throw new Error(`The provided key was not valid: ${accountKey}`);
+    }
+
     this.callbacks = {};
+    this.serverUrl = params.serverUrl;
+    this.accountKey = accountKey;
     this.unfundedWatcherTimeout = null;
   }
 

--- a/src/types/data.ts
+++ b/src/types/data.ts
@@ -1,7 +1,22 @@
 import BigNumber from "bignumber.js";
 import { AssetType } from "stellar-base";
-import { Horizon, ServerApi } from "stellar-sdk";
+import {
+  BadRequestError,
+  Horizon,
+  NetworkError,
+  NotFoundError,
+  ServerApi,
+} from "stellar-sdk";
 import { EffectType } from "../constants/data";
+
+interface NotFundedError {
+  isUnfunded: boolean;
+}
+
+export type FetchAccountError =
+  | BadRequestError
+  | NetworkError
+  | NotFoundError & NotFundedError;
 
 export type TradeId = string;
 export type OfferId = string;


### PR DESCRIPTION
- fetchAccountDetails now adds a property to thrown errors indicating if the account seems unfunded.
- When watchAccountDetails finds an unfunded account, it will now retry two seconds later (without an error) until the account comes back.
- Add a function to check if an account is funded.
- Add some errors and validation around the keys passed to DataProvider.