### PR TITLE
Set networks per-key

### DIFF
--- a/config/polyfills.js
+++ b/config/polyfills.js
@@ -1,1 +1,2 @@
 global.regeneratorRuntime = require("regenerator-runtime");
+global.fetch = require("jest-fetch-mock");

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,6 +4,7 @@
 module.exports = {
   // Automatically clear mock calls and instances between every test
   clearMocks: true,
+  automock: false,
 
   setupFiles: ["<rootDir>/config/polyfills.js"],
 

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "concurrently": "^4.1.1",
     "husky": "^1.3.1",
     "jest": "^24.7.1",
+    "jest-fetch-mock": "^2.1.2",
     "lint-staged": "^8.1.5",
     "prettier": "^1.17.0",
     "regenerator-runtime": "^0.13.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/wallet-sdk",
-  "version": "0.0.4-rc.4",
+  "version": "0.0.5-rc.1",
   "description": "Libraries to help you write Stellar-enabled wallets in Javascript",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/playground/src/App.js
+++ b/playground/src/App.js
@@ -11,8 +11,6 @@ import Offers from "components/Offers";
 import Trades from "components/Trades";
 import Transfers from "components/Transfers";
 
-StellarSdk.Network.usePublicNetwork();
-
 const El = styled.div`
   display: flex;
   font-size: 0.8em;

--- a/src/KeyManager.test.ts
+++ b/src/KeyManager.test.ts
@@ -61,12 +61,11 @@ describe("KeyManager", function() {
     const testKeyManager = new KeyManager({
       keyStore: testStore,
     });
+    const network = StellarBase.Networks.TESTNET;
 
     testKeyManager.registerEncrypter(IdentityEncrypter);
 
-    StellarBase.Network.useTestNetwork();
-
-    const keypair = StellarBase.Keypair.master();
+    const keypair = StellarBase.Keypair.master(network);
 
     // save this key
     const keyMetadata = await testKeyManager.storeKey({
@@ -74,6 +73,7 @@ describe("KeyManager", function() {
         type: KeyType.plaintextKey,
         publicKey: keypair.publicKey(),
         privateKey: keypair.secret(),
+        network,
       },
       password: "test",
       encrypterName: "IdentityEncrypter",
@@ -84,7 +84,10 @@ describe("KeyManager", function() {
       "0",
     );
 
-    const transaction = new StellarBase.TransactionBuilder(source, { fee: 100 })
+    const transaction = new StellarBase.TransactionBuilder(source, {
+      fee: 100,
+      networkPassphrase: network,
+    })
       .addOperation(StellarBase.Operation.inflation({}))
       .setTimeout(StellarBase.TimeoutInfinite)
       .build();

--- a/src/KeyManager.ts
+++ b/src/KeyManager.ts
@@ -298,10 +298,7 @@ export class KeyManager {
     const keyHandler = this.keyHandlerMap[key.type];
 
     const signedTransaction = await keyHandler.signTransaction({
-      transaction: new Transaction(
-        transaction,
-        network_passphrase || key.network || Networks.PUBLIC,
-      ),
+      transaction: new Transaction(transaction, key.network || Networks.PUBLIC),
       key,
     });
 

--- a/src/types/keys.ts
+++ b/src/types/keys.ts
@@ -5,6 +5,8 @@ export interface BaseKey {
   extra?: any;
   path?: string;
   publicKey: string;
+  // if the network is not set, the key is assumed to be on Networks.PUBLIC
+  network?: string;
   type: KeyType | string;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1777,6 +1777,14 @@ crc@^3.5.0:
   dependencies:
     buffer "^5.1.0"
 
+cross-fetch@^2.2.2:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-2.2.3.tgz#e8a0b3c54598136e037f8650f8e823ccdfac198e"
+  integrity sha512-PrWWNH3yL2NYIb/7WF/5vFG3DCQiXDOVf8k3ijatbrtnwNuhMWLC7YF7uqf53tbTFDzHIUD8oITw4Bxt8ST3Nw==
+  dependencies:
+    node-fetch "2.1.2"
+    whatwg-fetch "2.0.4"
+
 cross-spawn@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
@@ -3120,6 +3128,14 @@ jest-environment-node@^24.7.1:
     jest-mock "^24.7.0"
     jest-util "^24.7.1"
 
+jest-fetch-mock@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/jest-fetch-mock/-/jest-fetch-mock-2.1.2.tgz#1260b347918e3931c4ec743ceaf60433da661bd0"
+  integrity sha512-tcSR4Lh2bWLe1+0w/IwvNxeDocMI/6yIA2bijZ0fyWxC4kQ18lckQ1n7Yd40NKuisGmcGBRFPandRXrW/ti/Bw==
+  dependencies:
+    cross-fetch "^2.2.2"
+    promise-polyfill "^7.1.1"
+
 jest-get-type@^24.3.0:
   version "24.3.0"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-24.3.0.tgz#582cfd1a4f91b5cdad1d43d2932f816d543c65da"
@@ -3973,6 +3989,11 @@ node-cleanup@^2.1.2:
   resolved "https://registry.yarnpkg.com/node-cleanup/-/node-cleanup-2.1.2.tgz#7ac19abd297e09a7f72a71545d951b517e4dde2c"
   integrity sha1-esGavSl+Caf3KnFUXZUbUX5N3iw=
 
+node-fetch@2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.1.2.tgz#ab884e8e7e57e38a944753cec706f788d1768bb5"
+  integrity sha1-q4hOjn5X44qUR1POxwb3iNF2i7U=
+
 node-gyp-build@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.1.0.tgz#3bc3dd7dd4aafecaf64a2e3729e785bc3cdea565"
@@ -4451,6 +4472,11 @@ progress@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
+
+promise-polyfill@^7.1.1:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/promise-polyfill/-/promise-polyfill-7.1.2.tgz#ab05301d8c28536301622d69227632269a70ca3b"
+  integrity sha512-FuEc12/eKqqoRYIGBrUptCBRhobL19PS2U31vMNTfyck1FxPyMfgsXyW4Mav85y/ZN1hop3hOwRlUDok23oYfQ==
 
 prompts@^2.0.1:
   version "2.0.4"
@@ -5727,6 +5753,11 @@ whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.3:
   integrity sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==
   dependencies:
     iconv-lite "0.4.24"
+
+whatwg-fetch@2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz#dde6a5df315f9d39991aa17621853d720b85566f"
+  integrity sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==
 
 whatwg-mimetype@^2.1.0, whatwg-mimetype@^2.2.0:
   version "2.3.0"


### PR DESCRIPTION
- Add a field to the `Key` type, `network`. When absent, assume the key to be Networks.PUBLIC.
- Remove the deprecated methods for setting Network.
- When checking a challenge response, check that the network passphrase matches the key's network.
- If the challenge doesn't include a network passphrase, ignore it.
- Bump to v0.0.5-rc.1.