### PR TITLE
watchTransaction

### DIFF
--- a/plans/authservers.md
+++ b/plans/authservers.md
@@ -28,5 +28,5 @@ interface GetAuthTokenParams {
   publicKey: PublicKey;
 }
 
-const jwt = await KeyManager.getAuthToken(params: GetAuthTokenParams);
+const jwt = await KeyManager.fetchAuthToken(params: GetAuthTokenParams);
 ```

--- a/playground/src/components/AccountDetails.js
+++ b/playground/src/components/AccountDetails.js
@@ -1,4 +1,5 @@
 import React, { Component } from "react";
+import Json from "react-json-view";
 
 class AccountDetails extends Component {
   state = {
@@ -83,9 +84,7 @@ class AccountDetails extends Component {
                 <li key={time.toString()}>{time.toString()}</li>
               ))}
             </ul>
-            {accountDetails && (
-              <pre>{JSON.stringify(accountDetails, null, 2)}</pre>
-            )}
+            {accountDetails && <Json src={accountDetails} />}
           </>
         )}
 

--- a/playground/src/components/Authorization.js
+++ b/playground/src/components/Authorization.js
@@ -22,7 +22,7 @@ class Authorization extends Component {
       "https://transfer-dot-jewel-api-dev.appspot.com",
     );
 
-    depositProvider.setBearerToken("testtesttest");
+    depositProvider.setAuthToken("testtesttest");
 
     this.setState({ depositProvider });
 

--- a/playground/src/components/KeyEntry.js
+++ b/playground/src/components/KeyEntry.js
@@ -74,13 +74,13 @@ export default class KeyEntry extends Component {
     }
   };
 
-  _getAuthToken = async (authServer) => {
+  _fetchAuthToken = async (authServer) => {
     const { keyManager, password, keyMetadata } = this.state;
     this.setState({ authToken: null });
     localStorage.setItem("authServer", authServer);
 
     try {
-      const authToken = await keyManager.getAuthToken({
+      const authToken = await keyManager.fetchAuthToken({
         id: keyMetadata.id,
         password,
         authServer,
@@ -118,7 +118,7 @@ export default class KeyEntry extends Component {
           <form
             onSubmit={(ev) => {
               ev.preventDefault();
-              this._getAuthToken(authServer);
+              this._fetchAuthToken(authServer);
             }}
           >
             <label>

--- a/playground/src/components/TransferProvider.js
+++ b/playground/src/components/TransferProvider.js
@@ -30,7 +30,10 @@ class TransferProvider extends Component {
   }
 
   _setUrl = (url) => {
-    const depositProvider = new WalletSdk.DepositProvider(url);
+    const depositProvider = new WalletSdk.DepositProvider(
+      url,
+      this.props.dataProvider.getAccountKey(),
+    );
 
     this.setState({
       depositProvider,
@@ -51,9 +54,7 @@ class TransferProvider extends Component {
       transactions,
       transactionError,
     } = this.state;
-    const { dataProvider, authToken } = this.props;
-
-    const accountKey = dataProvider.getAccountKey();
+    const { authToken } = this.props;
 
     return (
       <div>
@@ -113,7 +114,6 @@ class TransferProvider extends Component {
                   }
                   depositProvider
                     .fetchTransactions({
-                      account: accountKey,
                       asset_code: assetCode,
                     })
                     .then((transactions) =>

--- a/playground/src/components/TransferProvider.js
+++ b/playground/src/components/TransferProvider.js
@@ -110,7 +110,7 @@ class TransferProvider extends Component {
                 theme={ButtonThemes.primary}
                 onClick={() => {
                   if (authToken) {
-                    depositProvider.setBearerToken(authToken);
+                    depositProvider.setAuthToken(authToken);
                   }
                   depositProvider
                     .fetchTransactions({

--- a/src/KeyManager.test.ts
+++ b/src/KeyManager.test.ts
@@ -106,7 +106,7 @@ describe("KeyManager", function() {
     ).toEqual(true);
   });
 
-  describe("getAuthToken", () => {
+  describe("fetchAuthToken", () => {
     beforeEach(() => {
       // @ts-ignore
       fetch.resetMocks();
@@ -120,7 +120,7 @@ describe("KeyManager", function() {
       });
       try {
         // @ts-ignore
-        await testKeyManager.getAuthToken({});
+        await testKeyManager.fetchAuthToken({});
         expect("This test failed").toBe(null);
       } catch (e) {
         expect(e).toBeTruthy();
@@ -163,7 +163,7 @@ describe("KeyManager", function() {
       });
 
       try {
-        await testKeyManager.getAuthToken({
+        await testKeyManager.fetchAuthToken({
           id: keyMetadata.id,
           password,
           authServer,
@@ -212,7 +212,7 @@ describe("KeyManager", function() {
       });
 
       try {
-        await testKeyManager.getAuthToken({
+        await testKeyManager.fetchAuthToken({
           id: keyMetadata.id,
           password,
           authServer,

--- a/src/KeyManager.ts
+++ b/src/KeyManager.ts
@@ -250,7 +250,7 @@ export class KeyManager {
    * @returns {Promise<string>} authToken JWT
    */
   // tslint:enable max-line-length
-  public async getAuthToken({
+  public async fetchAuthToken({
     id,
     password,
     authServer,

--- a/src/data/DataProvider.ts
+++ b/src/data/DataProvider.ts
@@ -11,6 +11,7 @@ import {
   Offer,
   Trade,
   Transfer,
+  WatcherParams,
 } from "../types";
 
 import { makeDisplayableBalances } from "./makeDisplayableBalances";
@@ -21,11 +22,6 @@ import { makeDisplayableTransfers } from "./makeDisplayableTransfers";
 export interface DataProviderParams {
   serverUrl: string;
   accountOrKey: Account | string;
-}
-
-export interface WatcherParams {
-  onMessage: (accountDetails: AccountDetails) => void;
-  onError: (error: any) => void;
 }
 
 function isAccount(obj: any): obj is Account {
@@ -188,7 +184,9 @@ export class DataProvider {
    * If the account doesn't exist yet, it will re-check it every 2 seconds.
    * Returns a function you can execute to stop the watcher.
    */
-  public watchAccountDetails(params: WatcherParams): () => void {
+  public watchAccountDetails(
+    params: WatcherParams<AccountDetails>,
+  ): () => void {
     const { onMessage, onError } = params;
 
     this.fetchAccountDetails()

--- a/src/transfers/DepositProvider.test.ts
+++ b/src/transfers/DepositProvider.test.ts
@@ -1,3 +1,4 @@
+import StellarSdk from "stellar-sdk";
 import { DepositProvider } from "./DepositProvider";
 
 import { DepositInfo } from "../types";
@@ -22,7 +23,10 @@ describe("fetchFinalFee", () => {
       },
     };
 
-    const provider = new DepositProvider("test");
+    const provider = new DepositProvider(
+      "test",
+      StellarSdk.Keypair.random().publicKey(),
+    );
 
     // manually set info
     provider.info = { deposit: info, withdraw: {} };
@@ -53,7 +57,10 @@ describe("fetchFinalFee", () => {
       },
     };
 
-    const provider = new DepositProvider("test");
+    const provider = new DepositProvider(
+      "test",
+      StellarSdk.Keypair.random().publicKey(),
+    );
 
     provider.info = { deposit: info, withdraw: {} };
 

--- a/src/transfers/DepositProvider.test.ts
+++ b/src/transfers/DepositProvider.test.ts
@@ -1,7 +1,8 @@
+import sinon from "sinon";
 import StellarSdk from "stellar-sdk";
 import { DepositProvider } from "./DepositProvider";
 
-import { DepositInfo } from "../types";
+import { DepositInfo, Transaction, TransactionStatus } from "../types";
 
 describe("fetchFinalFee", () => {
   test("AnchorUSD", async () => {
@@ -71,5 +72,209 @@ describe("fetchFinalFee", () => {
         type: "",
       }),
     ).toEqual(0.05);
+  });
+});
+
+describe("watchTransaction", () => {
+  let clock: sinon.SinonFakeTimers;
+
+  beforeEach(() => {
+    clock = sinon.useFakeTimers(0);
+    // @ts-ignore
+    fetch.resetMocks();
+  });
+
+  afterEach(() => {
+    clock.restore();
+  });
+
+  // suite-wide consts
+  const transferServer = "https://www.stellar.org/transfers";
+  const info: any = {
+    deposit: {
+      SMX: {
+        enabled: true,
+        fee_fixed: 0,
+        fee_percent: 0,
+        min_amount: 1500,
+        max_amount: 1000000,
+        fields: {
+          email_address: {
+            description: "your email address for transaction status updates",
+            optional: true,
+          },
+          amount: { description: "amount in cents that you plan to deposit" },
+          type: {
+            description: "type of deposit to make",
+            choices: ["SPEI", "cash"],
+          },
+        },
+      },
+    },
+    withdraw: {
+      SMX: {
+        enabled: true,
+        fee_fixed: 0,
+        fee_percent: 0,
+        min_amount: 0.1,
+        max_amount: 1000000,
+        types: {
+          bank_account: {
+            fields: { dest: { description: "your bank account number" } },
+          },
+        },
+      },
+    },
+    fee: { enabled: false },
+    transactions: { enabled: true },
+    transaction: { enabled: true },
+  };
+
+  const pendingTransaction: Transaction = {
+    kind: "deposit",
+    id: "TEST",
+    status: TransactionStatus.pending_anchor,
+  };
+  const successfulTransaction: Transaction = {
+    kind: "deposit",
+    id: "TEST",
+    status: TransactionStatus.completed,
+  };
+  const failedTransaction: Transaction = {
+    kind: "deposit",
+    id: "TEST",
+    status: TransactionStatus.error,
+  };
+
+  test("One success", async (done) => {
+    const provider = new DepositProvider(
+      transferServer,
+      StellarSdk.Keypair.random().publicKey(),
+    );
+
+    const onMessage = sinon.spy((transaction) => {
+      done("onMessage incorrectly called with", transaction);
+    });
+    const onSuccess = sinon.spy(() => {
+      done();
+    });
+    const onError = sinon.spy((e) => {
+      done("onMessage incorrectly called with", e);
+    });
+
+    // first, mock fetching info
+    // @ts-ignore
+    fetch.mockResponseOnce(JSON.stringify(info));
+    await provider.fetchSupportedAssets();
+
+    // then, queue up a success
+    // @ts-ignore
+    fetch.mockResponses([JSON.stringify(successfulTransaction)]);
+
+    // start watching
+    provider.watchTransaction({
+      asset_code: "SMX",
+      id: successfulTransaction.id,
+      onMessage,
+      onSuccess,
+      onError,
+      timeout: 10,
+    });
+
+    // nothing should run at first
+    expect(onMessage.callCount).toBe(0);
+    expect(onSuccess.callCount).toBe(0);
+    expect(onError.callCount).toBe(0);
+
+    // wait a second, then done will call back success
+    clock.next();
+  });
+
+  test("One pending message", async (done) => {
+    const provider = new DepositProvider(
+      transferServer,
+      StellarSdk.Keypair.random().publicKey(),
+    );
+
+    const onMessage = sinon.spy(() => {
+      done();
+    });
+    const onSuccess = sinon.spy((transaction) => {
+      done("onSuccess incorrectly called with", transaction);
+    });
+    const onError = sinon.spy((e) => {
+      done("onMessage incorrectly called with", e);
+    });
+
+    // first, mock fetching info
+    // @ts-ignore
+    fetch.mockResponseOnce(JSON.stringify(info));
+    await provider.fetchSupportedAssets();
+
+    // then, queue up a success
+    // @ts-ignore
+    fetch.mockResponses([JSON.stringify(pendingTransaction)]);
+
+    // start watching
+    provider.watchTransaction({
+      asset_code: "SMX",
+      id: successfulTransaction.id,
+      onMessage,
+      onSuccess,
+      onError,
+      timeout: 10,
+    });
+
+    // nothing should run at first
+    expect(onMessage.callCount).toBe(0);
+    expect(onSuccess.callCount).toBe(0);
+    expect(onError.callCount).toBe(0);
+
+    // wait a second, then done will call back success
+    clock.next();
+  });
+
+  test("One error", async (done) => {
+    const provider = new DepositProvider(
+      transferServer,
+      StellarSdk.Keypair.random().publicKey(),
+    );
+
+    const onMessage = sinon.spy((transaction) => {
+      done("onMessage incorrectly called with", transaction);
+    });
+    const onSuccess = sinon.spy((transaction) => {
+      done("onSuccess incorrectly called with", transaction);
+    });
+    const onError = sinon.spy(() => {
+      done();
+    });
+
+    // first, mock fetching info
+    // @ts-ignore
+    fetch.mockResponseOnce(JSON.stringify(info));
+    await provider.fetchSupportedAssets();
+
+    // then, queue up a success
+    // @ts-ignore
+    fetch.mockResponses([JSON.stringify(failedTransaction)]);
+
+    // start watching
+    provider.watchTransaction({
+      asset_code: "SMX",
+      id: successfulTransaction.id,
+      onMessage,
+      onSuccess,
+      onError,
+      timeout: 10,
+    });
+
+    // nothing should run at first
+    expect(onMessage.callCount).toBe(0);
+    expect(onSuccess.callCount).toBe(0);
+    expect(onError.callCount).toBe(0);
+
+    // wait a second, then done will call back success
+    clock.next();
   });
 });

--- a/src/transfers/TransferProvider.ts
+++ b/src/transfers/TransferProvider.ts
@@ -23,7 +23,7 @@ export abstract class TransferProvider {
   public operation: "deposit" | "withdraw";
   public account: string;
   public info?: Info;
-  public bearerToken?: string;
+  public authToken?: string;
 
   constructor(
     transferServer: string,
@@ -57,9 +57,9 @@ export abstract class TransferProvider {
 
   protected getHeaders(): Headers {
     return new Headers(
-      this.bearerToken
+      this.authToken
         ? {
-            Authorization: `Bearer ${this.bearerToken}`,
+            Authorization: `Bearer ${this.authToken}`,
           }
         : {},
     );
@@ -67,11 +67,11 @@ export abstract class TransferProvider {
 
   /**
    * Set the bearer token fetched by KeyManager's fetchAuthToken function.
-   * (setBearerToken and fetchAuthToken are in two different classes because
+   * (setAuthToken and fetchAuthToken are in two different classes because
    * fetchAuthToken requires signing keys, which requires KeyManager's helpers.)
    */
-  public setBearerToken(token: string) {
-    this.bearerToken = token;
+  public setAuthToken(token: string) {
+    this.authToken = token;
   }
 
   public abstract fetchSupportedAssets():
@@ -198,11 +198,11 @@ export abstract class TransferProvider {
     const isAuthRequired = !!assetInfo.authentication_required;
 
     // if the asset requires authentication, require an auth_token
-    if (isAuthRequired && !this.bearerToken) {
+    if (isAuthRequired && !this.authToken) {
       throw new Error(
         `
         Asset ${asset_code} requires authentication. Run KeyManager's 
-        fetchAuthToken function, then run setBearerToken to set it.
+        fetchAuthToken function, then run setAuthToken to set it.
         `,
       );
     }

--- a/src/transfers/TransferProvider.ts
+++ b/src/transfers/TransferProvider.ts
@@ -197,7 +197,7 @@ export abstract class TransferProvider {
       throw new Error(
         `
         Asset ${asset_code} requires authentication. Run KeyManager's 
-        getAuthToken function, then run setBearerToken to set it.
+        fetchAuthToken function, then run setBearerToken to set it.
         `,
       );
     }

--- a/src/transfers/TransferProvider.ts
+++ b/src/transfers/TransferProvider.ts
@@ -65,6 +65,11 @@ export abstract class TransferProvider {
     );
   }
 
+  /**
+   * Set the bearer token fetched by KeyManager's fetchAuthToken function.
+   * (setBearerToken and fetchAuthToken are in two different classes because
+   * fetchAuthToken requires signing keys, which requires KeyManager's helpers.)
+   */
   public setBearerToken(token: string) {
     this.bearerToken = token;
   }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,4 @@
 export * from "./data";
 export * from "./keys";
 export * from "./transfers";
+export * from "./watchers";

--- a/src/types/transfers.ts
+++ b/src/types/transfers.ts
@@ -285,7 +285,12 @@ export interface WithdrawTransaction extends BaseTransaction {
 
 export type Transaction = DepositTransaction | WithdrawTransaction;
 
-export interface TransactionArgs {
+export interface GetAuthStatusArgs {
+  asset_code: string;
+  account: string;
+}
+
+export interface TransactionsArgs {
   asset_code: string;
   account: string;
   show_all_transactions?: boolean;
@@ -293,4 +298,10 @@ export interface TransactionArgs {
   limit?: number;
   kind?: string;
   paging_id?: string;
+}
+
+export interface TransactionArgs {
+  asset_code: string;
+  account: string;
+  id: string;
 }

--- a/src/types/transfers.ts
+++ b/src/types/transfers.ts
@@ -1,4 +1,5 @@
 import { TransferResponseType } from "../constants/transfers";
+import { WatcherParams } from "./watchers";
 
 export interface GetKycArgs {
   request: WithdrawRequest | DepositRequest;
@@ -299,4 +300,11 @@ export interface TransactionsArgs {
 export interface TransactionArgs {
   asset_code: string;
   id: string;
+}
+
+export interface WatchTransactionArgs
+  extends TransactionArgs,
+    WatcherParams<Transaction> {
+  onSuccess: (payload: Transaction) => void;
+  timeout?: number;
 }

--- a/src/types/transfers.ts
+++ b/src/types/transfers.ts
@@ -107,7 +107,6 @@ export interface WithdrawRequest {
   asset_code: string;
   dest: string;
   dest_extra: string;
-  account?: string;
   memo?: Memo;
   memoType?: string;
   [key: string]: any;
@@ -115,7 +114,6 @@ export interface WithdrawRequest {
 
 export interface DepositRequest {
   asset_code: string;
-  account: string;
   memo?: Memo;
   memoType?: string;
   emailAddress?: string;
@@ -287,12 +285,10 @@ export type Transaction = DepositTransaction | WithdrawTransaction;
 
 export interface GetAuthStatusArgs {
   asset_code: string;
-  account: string;
 }
 
 export interface TransactionsArgs {
   asset_code: string;
-  account: string;
   show_all_transactions?: boolean;
   no_older_than?: string;
   limit?: number;
@@ -302,6 +298,5 @@ export interface TransactionsArgs {
 
 export interface TransactionArgs {
   asset_code: string;
-  account: string;
   id: string;
 }

--- a/src/types/watchers.ts
+++ b/src/types/watchers.ts
@@ -1,0 +1,4 @@
+export interface WatcherParams<T> {
+  onMessage: (payload: T) => void;
+  onError: (error: any) => void;
+}


### PR DESCRIPTION
- Name auth token functions more consistently.
  - getAuthToken -> fetchAuthToken
  - setBearerToken -> setAuthToken
- Explain why fetchAuthToken is on KeyManager and setAuthToken on DepositProvider / WithdrawProvider
- Add a new generic type for watchers 
- Add a function, watchTransaction, to poll the transaction endpoint until the transaction stops pending
- Add tests for the watcher