### PR TITLE
watchTransaction ergonomics

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/wallet-sdk",
-  "version": "0.0.6-rc.4",
+  "version": "0.0.6-rc.5",
   "description": "Libraries to help you write Stellar-enabled wallets in Javascript",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/transfers/TransferProvider.ts
+++ b/src/transfers/TransferProvider.ts
@@ -18,6 +18,14 @@ import { TransactionStatus } from "../constants/transfers";
 
 import { parseInfo } from "./parseInfo";
 
+interface WatchRegistryAsset {
+  [asset_code: string]: boolean;
+}
+
+interface WatchRegistry {
+  [asset_code: string]: WatchRegistryAsset;
+}
+
 /**
  * TransferProvider is the base class for WithdrawProvider and DepositProvider.
  */
@@ -29,6 +37,7 @@ export abstract class TransferProvider {
   public authToken?: string;
 
   protected _transactionWatcher?: number;
+  protected _watchRegistry: WatchRegistry;
 
   constructor(
     transferServer: string,
@@ -50,6 +59,8 @@ export abstract class TransferProvider {
     this.transferServer = transferServer;
     this.operation = operation;
     this.account = account;
+
+    this._watchRegistry = {};
   }
 
   protected async fetchInfo(): Promise<Info> {
@@ -153,36 +164,58 @@ export abstract class TransferProvider {
     onSuccess,
     onError,
     timeout = 5000,
+    isRetry = false,
   }: WatchTransactionArgs): () => void {
-    this._transactionWatcher = setTimeout(async () => {
-      try {
-        const transaction = await this.fetchTransaction(
-          { asset_code, id },
-          true,
-        );
+    // if it's a first blush, drop it in the registry
+    if (!isRetry) {
+      this._watchRegistry = {
+        [asset_code]: {
+          ...(this._watchRegistry[asset_code] || {}),
+          [id]: true,
+        },
+      };
+    }
+
+    // do this all asynchronously (since this func needs to return a cancel fun)
+    this.fetchTransaction({ asset_code, id }, true)
+      .then((transaction) => {
+        if (
+          !(
+            this._watchRegistry[asset_code] &&
+            this._watchRegistry[asset_code][id]
+          )
+        ) {
+          return;
+        }
 
         if (transaction.status.indexOf("pending") === 0) {
-          this.watchTransaction({
-            asset_code,
-            id,
-            onMessage,
-            onSuccess,
-            onError,
-            timeout,
-          });
+          this._transactionWatcher = setTimeout(async () => {
+            this.watchTransaction({
+              asset_code,
+              id,
+              onMessage,
+              onSuccess,
+              onError,
+              timeout,
+              isRetry: true,
+            });
+          }, 1000) as any;
           onMessage(transaction);
         } else if (transaction.status === TransactionStatus.completed) {
           onSuccess(transaction);
         } else {
           onError(transaction);
         }
-      } catch (e) {
+      })
+      .catch((e) => {
         onError(e);
-      }
-    }, 1000) as any;
+      });
 
     return () => {
-      clearTimeout(this._transactionWatcher);
+      if (this._transactionWatcher) {
+        this._watchRegistry[asset_code][id] = false;
+        clearTimeout(this._transactionWatcher);
+      }
     };
   }
 

--- a/src/transfers/TransferProvider.ts
+++ b/src/transfers/TransferProvider.ts
@@ -199,7 +199,7 @@ export abstract class TransferProvider {
               timeout,
               isRetry: true,
             });
-          }, 1000) as any;
+          }, timeout) as any;
           onMessage(transaction);
         } else if (transaction.status === TransactionStatus.completed) {
           onSuccess(transaction);

--- a/src/types/transfers.ts
+++ b/src/types/transfers.ts
@@ -295,4 +295,5 @@ export interface WatchTransactionArgs
     WatcherParams<Transaction> {
   onSuccess: (payload: Transaction) => void;
   timeout?: number;
+  isRetry?: boolean;
 }


### PR DESCRIPTION
- Always fetch first, and setTimeout afterwards
- Since this creates a race scenario where a dev can cancel before the first response comes back, add a registry that controls whether to continue or not
- Add a retry flag because that might be necessary