### PR TITLE
Watchers update

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/wallet-sdk",
-  "version": "0.0.6-rc.6",
+  "version": "0.0.6-rc.7",
   "description": "Libraries to help you write Stellar-enabled wallets in Javascript",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/transfers/DepositProvider.test.ts
+++ b/src/transfers/DepositProvider.test.ts
@@ -94,20 +94,29 @@ describe("watchOneTransaction", () => {
   // suite-wide consts
   const transferServer = "https://www.stellar.org/transfers";
 
-  const pendingTransaction: Transaction = {
-    kind: "deposit",
-    id: "TEST",
-    status: TransactionStatus.pending_anchor,
+  const pendingTransaction = (n: number = 0): Transaction => {
+    return {
+      kind: "deposit",
+      id: "TEST",
+      status: TransactionStatus.pending_anchor,
+      status_eta: n,
+    };
   };
-  const successfulTransaction: Transaction = {
-    kind: "deposit",
-    id: "TEST",
-    status: TransactionStatus.completed,
+  const successfulTransaction = (n: number = 0): Transaction => {
+    return {
+      kind: "deposit",
+      id: "TEST",
+      status: TransactionStatus.completed,
+      status_eta: n,
+    };
   };
-  const failedTransaction: Transaction = {
-    kind: "deposit",
-    id: "TEST",
-    status: TransactionStatus.error,
+  const failedTransaction = (n: number = 0): Transaction => {
+    return {
+      kind: "deposit",
+      id: "TEST",
+      status: TransactionStatus.error,
+      status_eta: n,
+    };
   };
 
   beforeEach(async () => {
@@ -144,12 +153,12 @@ describe("watchOneTransaction", () => {
 
     // queue up a success
     // @ts-ignore
-    fetch.mockResponses([JSON.stringify(successfulTransaction)]);
+    fetch.mockResponses([JSON.stringify(successfulTransaction())]);
 
     // start watching
     provider.watchOneTransaction({
       asset_code: "SMX",
-      id: successfulTransaction.id,
+      id: successfulTransaction(0).id,
       onMessage,
       onSuccess,
       onError,
@@ -178,12 +187,12 @@ describe("watchOneTransaction", () => {
 
     // queue up a success
     // @ts-ignore
-    fetch.mockResponses([JSON.stringify(pendingTransaction)]);
+    fetch.mockResponses([JSON.stringify(pendingTransaction(0))]);
 
     // start watching
     provider.watchOneTransaction({
       asset_code: "SMX",
-      id: successfulTransaction.id,
+      id: successfulTransaction(0).id,
       onMessage,
       onSuccess,
       onError,
@@ -212,12 +221,12 @@ describe("watchOneTransaction", () => {
 
     // then, queue up a success
     // @ts-ignore
-    fetch.mockResponses([JSON.stringify(failedTransaction)]);
+    fetch.mockResponses([JSON.stringify(failedTransaction(0))]);
 
     // start watching
     provider.watchOneTransaction({
       asset_code: "SMX",
-      id: successfulTransaction.id,
+      id: successfulTransaction(0).id,
       onMessage,
       onSuccess,
       onError,
@@ -247,16 +256,16 @@ describe("watchOneTransaction", () => {
     // queue up a success
     // @ts-ignore
     fetch.mockResponses(
-      [JSON.stringify(pendingTransaction), { status: 200 }],
-      [JSON.stringify(pendingTransaction), { status: 200 }],
-      [JSON.stringify(pendingTransaction), { status: 200 }],
-      [JSON.stringify(pendingTransaction), { status: 200 }],
+      [JSON.stringify(pendingTransaction(0)), { status: 200 }],
+      [JSON.stringify(pendingTransaction(1)), { status: 200 }],
+      [JSON.stringify(pendingTransaction(2)), { status: 200 }],
+      [JSON.stringify(pendingTransaction(3)), { status: 200 }],
     );
 
     // start watching
     provider.watchOneTransaction({
       asset_code: "SMX",
-      id: successfulTransaction.id,
+      id: successfulTransaction(0).id,
       onMessage,
       onSuccess,
       onError,
@@ -299,16 +308,16 @@ describe("watchOneTransaction", () => {
     // queue up a success
     // @ts-ignore
     fetch.mockResponses(
-      [JSON.stringify(pendingTransaction), { status: 200 }],
-      [JSON.stringify(successfulTransaction), { status: 200 }],
-      [JSON.stringify(successfulTransaction), { status: 200 }],
-      [JSON.stringify(successfulTransaction), { status: 200 }],
+      [JSON.stringify(pendingTransaction()), { status: 200 }],
+      [JSON.stringify(successfulTransaction()), { status: 200 }],
+      [JSON.stringify(successfulTransaction()), { status: 200 }],
+      [JSON.stringify(successfulTransaction()), { status: 200 }],
     );
 
     // start watching
     provider.watchOneTransaction({
       asset_code: "SMX",
-      id: successfulTransaction.id,
+      id: successfulTransaction(0).id,
       onMessage,
       onSuccess,
       onError,
@@ -359,16 +368,16 @@ describe("watchOneTransaction", () => {
     // queue up a success
     // @ts-ignore
     fetch.mockResponses(
-      [JSON.stringify(pendingTransaction), { status: 200 }],
-      [JSON.stringify(failedTransaction), { status: 200 }],
-      [JSON.stringify(failedTransaction), { status: 200 }],
-      [JSON.stringify(failedTransaction), { status: 200 }],
+      [JSON.stringify(pendingTransaction()), { status: 200 }],
+      [JSON.stringify(failedTransaction()), { status: 200 }],
+      [JSON.stringify(failedTransaction()), { status: 200 }],
+      [JSON.stringify(failedTransaction()), { status: 200 }],
     );
 
     // start watching
     provider.watchOneTransaction({
       asset_code: "SMX",
-      id: successfulTransaction.id,
+      id: successfulTransaction(0).id,
       onMessage,
       onSuccess,
       onError,
@@ -419,17 +428,17 @@ describe("watchOneTransaction", () => {
     // queue up a success
     // @ts-ignore
     fetch.mockResponses(
-      [JSON.stringify(pendingTransaction), { status: 200 }],
-      [JSON.stringify(pendingTransaction), { status: 200 }],
-      [JSON.stringify(failedTransaction), { status: 200 }],
-      [JSON.stringify(failedTransaction), { status: 200 }],
-      [JSON.stringify(failedTransaction), { status: 200 }],
+      [JSON.stringify(pendingTransaction(0)), { status: 200 }],
+      [JSON.stringify(pendingTransaction(1)), { status: 200 }],
+      [JSON.stringify(failedTransaction(2)), { status: 200 }],
+      [JSON.stringify(failedTransaction(3)), { status: 200 }],
+      [JSON.stringify(failedTransaction(4)), { status: 200 }],
     );
 
     // start watching
     provider.watchOneTransaction({
       asset_code: "SMX",
-      id: successfulTransaction.id,
+      id: successfulTransaction(0).id,
       onMessage,
       onSuccess,
       onError,

--- a/src/transfers/TransferProvider.ts
+++ b/src/transfers/TransferProvider.ts
@@ -236,16 +236,13 @@ export abstract class TransferProvider {
                 return isPending;
               }
 
-              // always use pending transactions
-              if (isPending) {
-                return true;
+              // if we've had the transaction before, only report updates
+              if (registeredTransaction) {
+                return isEqual(registeredTransaction, transaction);
               }
 
-              // then, only use transactions that have changed
-              if (
-                registeredTransaction &&
-                !isEqual(registeredTransaction, transaction)
-              ) {
+              // always use pending transactions
+              if (isPending) {
                 return true;
               }
 


### PR DESCRIPTION
- Only use the watchlist on the first run (so it doesn't bypass the thing that makes sure txes change)
- Make sure to save transactions in the registry, so txes only get acted on when they change
- Make the singleton watcher use the registry too
- Correctly show updates to transactions we've observed before, but are no longer pending