### PR TITLE
Transfer filtering

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/wallet-sdk",
-  "version": "0.0.6-rc.9",
+  "version": "0.0.6-rc.10",
   "description": "Libraries to help you write Stellar-enabled wallets in Javascript",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/types/transfers.ts
+++ b/src/types/transfers.ts
@@ -298,6 +298,7 @@ export interface TransactionParams {
 
 export interface WatchAllTransactionsParams extends WatcherParams<Transaction> {
   asset_code: string;
+  no_older_than?: string;
   watchlist?: string[];
   timeout?: number;
   isRetry?: boolean;


### PR DESCRIPTION
- Add support for no_older_than
- Have the watcher pass other params through to the fetcher
- Get rid of manual transaction filtering; instead, use the kind arg