### PR TITLE
Improve usability of Deposit/WithdrawProviders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,25 @@
 # Changelog
 
-**Breaking changes** will be clearly marked.
+## v0.0.7
+
+- Rename WithdrawInfo to WithdrawAssetInfoMap
+- Rename DepositInfo to DepositAssetInfoMap
+
+## v0.0.6
+
+- General: Get rid of export namespaces, since types weren't transfering over
+  properly. We now export all helper functions, classes, etc. directly.
+- General: Export `Types` object, which holds all types.
+- Data: Add support for SEP-10 auth, via `KeyManager#fetchAuthToken`.
+- Data: add an optional `network` property to keys; no network means assume
+  pubnet.
+- Data: Drop `KeyManager#loadAllKeyMetadata`; use `KeyManager#loadAllKeys`
+  instead.
+- Data: Encrypted keys now store a generic encrypted blob, which among other
+  things keeps public keys private by default.
+- Transfers: Add tools to watch pending transactions.
+- Transfers: Use snake-cased arguments for transfers, since some of them are the
+  same as snake-cased arguments requested by anchors.
 
 ## v0.0.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   - DepositProvider#deposit -> #startDeposit
 - Transfers: Fix fetchFinalFee parameters
 - Transfers: Add `DepositProvider#validateFields` to validate deposit fields
+- Transfers: Add `TransferProvider#getAsset` to fetch single assets
 
 ## [v0.0.6-rc.17](https://github.com/stellar/js-stellar-wallets/compare/v0.0.3-rc1...v0.0.6-rc.17)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   - DepositInfo -> DepositAssetInfoMap
   - WithdrawProvider#withdraw -> #startWithdraw
   - DepositProvider#deposit -> #startDeposit
+- Transfers: Fix fetchFinalFee parameters
 
 ## [v0.0.6-rc.17](https://github.com/stellar/js-stellar-wallets/compare/v0.0.3-rc1...v0.0.6-rc.17)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,14 @@
 # Changelog
 
-## v0.0.7
+## [Current](https://github.com/stellar/js-stellar-wallets/compare/v0.0.6-rc.17...master)
 
-- Rename WithdrawInfo to WithdrawAssetInfoMap
-- Rename DepositInfo to DepositAssetInfoMap
+- Rename some things for clarity
+  - WithdrawInfo -> WithdrawAssetInfoMap
+  - DepositInfo -> DepositAssetInfoMap
+  - WithdrawProvider#withdraw -> #startWithdraw
+  - DepositProvider#deposit -> #startDeposit
 
-## v0.0.6
+## [v0.0.6-rc.17](https://github.com/stellar/js-stellar-wallets/compare/v0.0.3-rc1...v0.0.6-rc.17)
 
 - General: Get rid of export namespaces, since types weren't transfering over
   properly. We now export all helper functions, classes, etc. directly.
@@ -17,11 +20,14 @@
   instead.
 - Data: Encrypted keys now store a generic encrypted blob, which among other
   things keeps public keys private by default.
+- Data: Rename "transfers" (what we call direct and path payments and other
+  similar operations) to "payments", so as to not confuse with the Transfers
+  arm.
 - Transfers: Add tools to watch pending transactions.
 - Transfers: Use snake-cased arguments for transfers, since some of them are the
   same as snake-cased arguments requested by anchors.
 
-## v0.0.3
+## v0.0.3-rc.1
 
 Initial (official) release! 🎉
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   - WithdrawProvider#withdraw -> #startWithdraw
   - DepositProvider#deposit -> #startDeposit
 - Transfers: Fix fetchFinalFee parameters
+- Transfers: Add `DepositProvider#validateFields` to validate deposit fields
 
 ## [v0.0.6-rc.17](https://github.com/stellar/js-stellar-wallets/compare/v0.0.3-rc1...v0.0.6-rc.17)
 

--- a/plans/sep6.md
+++ b/plans/sep6.md
@@ -41,7 +41,9 @@ interface GetKycParams {
 
 class TransferProvider {
   constructor(transferServer) {}
-  fetchSupportedAssets: () => Promise<WithdrawInfo> | Promise<DepositInfo>;
+  fetchSupportedAssets: () =>
+    | Promise<WithdrawAssetInfoMap>
+    | Promise<DepositAssetInfoMap>;
   fetchFinalFee: (params: FeeParams) => Promise<number>;
   fetchKycInBrowser: ({
     response: InteractiveKycNeeded,
@@ -75,7 +77,7 @@ interface WithdrawAssetInfo {
   }[];
 }
 
-interface WithdrawInfo {
+interface WithdrawAssetInfoMap {
   [assetCode: string]: WithdrawAssetInfo;
 }
 
@@ -87,7 +89,7 @@ interface DepositAssetInfo {
   fields: Field[];
 }
 
-interface DepositInfo {
+interface DepositAssetInfoMap {
   [assetCode: string]: DepositAssetInfo;
 }
 

--- a/src/transfers/DepositProvider.test.ts
+++ b/src/transfers/DepositProvider.test.ts
@@ -48,7 +48,6 @@ describe("fetchFinalFee", () => {
       await provider.fetchFinalFee({
         asset_code: info.USD.asset_code,
         amount: "15",
-        type: "simple",
       }),
     ).toEqual(5.15);
   });
@@ -81,7 +80,6 @@ describe("fetchFinalFee", () => {
       await provider.fetchFinalFee({
         asset_code: info.EUR.asset_code,
         amount: "10",
-        type: "simple",
       }),
     ).toEqual(0.05);
   });

--- a/src/transfers/DepositProvider.test.ts
+++ b/src/transfers/DepositProvider.test.ts
@@ -6,7 +6,7 @@ import { TransactionsResponse } from "../fixtures/TransactionsResponse";
 import { SMXTransferInfo } from "../fixtures/TransferInfoResponse";
 
 import { TransactionStatus } from "../constants/transfers";
-import { DepositInfo, Transaction } from "../types";
+import { DepositAssetInfoMap, Transaction } from "../types";
 
 const originalSetTimeout = global.setTimeout;
 
@@ -18,7 +18,7 @@ function sleep(time: number) {
 
 describe("fetchFinalFee", () => {
   test("AnchorUSD", async () => {
-    const info: DepositInfo = {
+    const info: DepositAssetInfoMap = {
       USD: {
         asset_code: "USD",
         fee: { type: "simple", fixed: 5, percent: 1 },
@@ -54,7 +54,7 @@ describe("fetchFinalFee", () => {
   });
 
   test("EUR from Nucleo staging", async () => {
-    const info: DepositInfo = {
+    const info: DepositAssetInfoMap = {
       EUR: {
         asset_code: "EUR",
         fee: { type: "simple", percent: 0.5 },

--- a/src/transfers/DepositProvider.test.ts
+++ b/src/transfers/DepositProvider.test.ts
@@ -6,7 +6,7 @@ import { TransactionsResponse } from "../fixtures/TransactionsResponse";
 import { SMXTransferInfo } from "../fixtures/TransferInfoResponse";
 
 import { TransactionStatus } from "../constants/transfers";
-import { DepositAssetInfoMap, Transaction } from "../types";
+import { DepositAssetInfoMap, Field, Transaction } from "../types";
 
 const originalSetTimeout = global.setTimeout;
 
@@ -702,5 +702,154 @@ describe("watchAllTransactions", () => {
 
     expect(onMessage.callCount).toBe(1);
     expect(onError.callCount).toBe(0);
+  });
+});
+
+describe("validateFields", () => {
+  const asset_code = "TEST";
+
+  function getProvider(fields: Field[]): DepositProvider {
+    const provider = new DepositProvider(
+      "https://test.com",
+      StellarSdk.Keypair.random().publicKey(),
+    );
+    provider.info = {
+      deposit: {
+        [asset_code]: {
+          asset_code,
+          fee: { type: "simple" },
+          fields,
+          min_amount: 0,
+        },
+      },
+      withdraw: {},
+    };
+
+    return provider;
+  }
+
+  test("returns true for empty fields", () => {
+    expect(getProvider([]).validateFields(asset_code, {})).toEqual(true);
+  });
+  test("returns true for correct response", () => {
+    const fields = [
+      {
+        description: "your email address for transaction status updates",
+        optional: true,
+        name: "email_address",
+      },
+      {
+        description: "amount in cents that you plan to deposit",
+        name: "amount",
+      },
+      {
+        description: "type of deposit to make",
+        choices: ["SPEI", "cash"],
+        name: "type",
+      },
+    ];
+
+    expect(
+      getProvider(fields).validateFields(asset_code, {
+        email: "asdf@asdf.com",
+        amount: "10",
+        type: "SPEI",
+      }),
+    ).toEqual(true);
+  });
+  test("returns false for invalid type", () => {
+    const fields = [
+      {
+        description: "your email address for transaction status updates",
+        optional: true,
+        name: "email_address",
+      },
+      {
+        description: "amount in cents that you plan to deposit",
+        name: "amount",
+      },
+      {
+        description: "type of deposit to make",
+        choices: ["SPEI", "cash"],
+        name: "type",
+      },
+    ];
+
+    expect(
+      getProvider(fields).validateFields(asset_code, {
+        email: "asdf@asdf.com",
+        amount: "10",
+        type: "asdlkfjasldkfjaskdlfjask",
+      }),
+    ).toEqual(false);
+  });
+  test("returns false for invalid email", () => {
+    const fields = [
+      {
+        description: "your email address for transaction status updates",
+        name: "email_address",
+      },
+      {
+        description: "amount in cents that you plan to deposit",
+        name: "amount",
+      },
+      {
+        description: "type of deposit to make",
+        choices: ["SPEI", "cash"],
+        name: "type",
+      },
+    ];
+
+    expect(
+      getProvider(fields).validateFields(asset_code, {
+        email: "asdf",
+        amount: "10",
+        type: "cash",
+      }),
+    ).toEqual(false);
+  });
+  test("returns false for invalid amount", () => {
+    const fields = [
+      {
+        description: "your email address for transaction status updates",
+        optional: true,
+        name: "email_address",
+      },
+      {
+        description: "amount in cents that you plan to deposit",
+        name: "amount",
+      },
+      {
+        description: "type of deposit to make",
+        choices: ["SPEI", "cash"],
+        name: "type",
+      },
+    ];
+
+    expect(
+      getProvider(fields).validateFields(asset_code, {
+        email: "asdf@asdf.com",
+        amount: "asdf",
+        type: "cash",
+      }),
+    ).toEqual(false);
+  });
+
+  test("real-world case", () => {
+    const fields = [
+      {
+        description: "Enter the amount in ARS that you plan to deposit",
+        name: "amount",
+      },
+      { description: "Enter your email address", name: "email_address" },
+    ];
+    const payload = {
+      amount: "255",
+      asset_code: "ARS",
+      email_address: "cassio@stellar.org",
+    };
+    expect(getProvider(fields).validateFields(asset_code, payload)).toEqual(
+      true,
+    );
   });
 });

--- a/src/transfers/DepositProvider.test.ts
+++ b/src/transfers/DepositProvider.test.ts
@@ -48,7 +48,7 @@ describe("fetchFinalFee", () => {
       await provider.fetchFinalFee({
         asset_code: info.USD.asset_code,
         amount: "15",
-        type: "",
+        type: "simple",
       }),
     ).toEqual(5.15);
   });
@@ -81,7 +81,7 @@ describe("fetchFinalFee", () => {
       await provider.fetchFinalFee({
         asset_code: info.EUR.asset_code,
         amount: "10",
-        type: "",
+        type: "simple",
       }),
     ).toEqual(0.05);
   });

--- a/src/transfers/DepositProvider.ts
+++ b/src/transfers/DepositProvider.ts
@@ -1,7 +1,7 @@
 import queryString from "query-string";
 
 import {
-  DepositInfo,
+  DepositAssetInfoMap,
   DepositRequest,
   FetchKycInBrowserParams,
   TransferError,
@@ -106,7 +106,7 @@ export class DepositProvider extends TransferProvider {
    * Fetch the assets that the deposit provider supports, along with details
    * about depositing that asset.
    */
-  public async fetchSupportedAssets(): Promise<DepositInfo> {
+  public async fetchSupportedAssets(): Promise<DepositAssetInfoMap> {
     const { deposit } = await this.fetchInfo();
 
     // seed internal registry objects with supported assets

--- a/src/transfers/DepositProvider.ts
+++ b/src/transfers/DepositProvider.ts
@@ -34,7 +34,7 @@ import { TransferProvider } from "./TransferProvider";
  *
  * // show fee to user, confirm amount and destination
  *
- * const depositResult = await depositProvider.deposit({
+ * const depositResult = await depositProvider.startDeposit({
  *   asset_code,
  *   // more optional properties
  * });
@@ -75,12 +75,12 @@ export class DepositProvider extends TransferProvider {
   }
 
   /**
-   * Make a deposit request.
+   * Start a deposit request.
    *
    * Note that all arguments must be in snake_case (which is what transfer
    * servers expect)!
    */
-  public async deposit(params: DepositRequest): Promise<TransferResponse> {
+  public async startDeposit(params: DepositRequest): Promise<TransferResponse> {
     const isAuthRequired = this.getAuthStatus("deposit", params.asset_code);
     const search = queryString.stringify({ ...params, account: this.account });
 
@@ -124,7 +124,7 @@ export class DepositProvider extends TransferProvider {
 
   /**
    * `fetchKycInBrowser` expects the original request parameters, the response
-   * object from `depositProvider.deposit()`, and a window instance.
+   * object from `depositProvider.startDeposit()`, and a window instance.
    *
    * Because pop-up blockers prevent new windows from being created, your app
    * will need to create one with `const popup = window.open()` and pass in the
@@ -179,7 +179,7 @@ export class DepositProvider extends TransferProvider {
       case "pending":
         return Promise.reject(kycResult);
       case "success": {
-        const retryResponse = await this.deposit(request);
+        const retryResponse = await this.startDeposit(request);
         // Since we've just successfully KYC'd, the only expected response is
         // success. Reject anything else.
         if (retryResponse.type === "ok") {

--- a/src/transfers/DepositProvider.ts
+++ b/src/transfers/DepositProvider.ts
@@ -133,6 +133,21 @@ export class DepositProvider extends TransferProvider {
   }
 
   /**
+   * Get one supported asset by code.
+   */
+  public getAsset(asset_code: string): DepositAssetInfo {
+    if (!this.info || !this.info[this.operation]) {
+      throw new Error(`Run fetchSupportedAssets before running getAsset!`);
+    }
+
+    if (!this.info[this.operation][asset_code]) {
+      throw new Error(`Asset not supported: ${asset_code}`);
+    }
+
+    return (this.info[this.operation] as DepositAssetInfoMap)[asset_code];
+  }
+
+  /**
    * `fetchKycInBrowser` expects the original request parameters, the response
    * object from `depositProvider.startDeposit()`, and a window instance.
    *

--- a/src/transfers/TransferProvider.ts
+++ b/src/transfers/TransferProvider.ts
@@ -2,7 +2,7 @@ import isEqual from "lodash/isEqual";
 import queryString from "query-string";
 
 import {
-  DepositInfo,
+  DepositAssetInfoMap,
   Fee,
   FeeParams,
   Info,
@@ -14,7 +14,7 @@ import {
   WatchAllTransactionsParams,
   WatcherResponse,
   WatchOneTransactionParams,
-  WithdrawInfo,
+  WithdrawAssetInfoMap,
 } from "../types";
 
 import { TransactionStatus } from "../constants/transfers";
@@ -115,8 +115,8 @@ export abstract class TransferProvider {
   }
 
   public abstract fetchSupportedAssets():
-    | Promise<WithdrawInfo>
-    | Promise<DepositInfo>;
+    | Promise<WithdrawAssetInfoMap>
+    | Promise<DepositAssetInfoMap>;
 
   /**
    * Fetch the list of transactions for a given account / asset code from the

--- a/src/transfers/TransferProvider.ts
+++ b/src/transfers/TransferProvider.ts
@@ -2,6 +2,7 @@ import isEqual from "lodash/isEqual";
 import queryString from "query-string";
 
 import {
+  DepositAssetInfo,
   DepositAssetInfoMap,
   Fee,
   FeeParams,
@@ -14,6 +15,7 @@ import {
   WatchAllTransactionsParams,
   WatcherResponse,
   WatchOneTransactionParams,
+  WithdrawAssetInfo,
   WithdrawAssetInfoMap,
 } from "../types";
 
@@ -117,6 +119,10 @@ export abstract class TransferProvider {
   public abstract fetchSupportedAssets():
     | Promise<WithdrawAssetInfoMap>
     | Promise<DepositAssetInfoMap>;
+
+  public abstract getAsset(
+    asset_code: string,
+  ): WithdrawAssetInfo | DepositAssetInfo;
 
   /**
    * Fetch the list of transactions for a given account / asset code from the

--- a/src/transfers/TransferProvider.ts
+++ b/src/transfers/TransferProvider.ts
@@ -479,6 +479,7 @@ export abstract class TransferProvider {
         const response = await fetch(
           `${this.transferServer}/fee?${queryString.stringify({
             ...params,
+            ...fee,
             operation: this.operation,
           })}`,
         );

--- a/src/transfers/TransferProvider.ts
+++ b/src/transfers/TransferProvider.ts
@@ -477,7 +477,10 @@ export abstract class TransferProvider {
         );
       case "complex":
         const response = await fetch(
-          `${this.transferServer}/fee?${queryString.stringify(params as any)}`,
+          `${this.transferServer}/fee?${queryString.stringify({
+            ...params,
+            operation: this.operation,
+          })}`,
         );
         const { fee: feeResponse } = await response.json();
         return feeResponse as number;

--- a/src/transfers/TransferProvider.ts
+++ b/src/transfers/TransferProvider.ts
@@ -465,6 +465,7 @@ export abstract class TransferProvider {
         `Can't get fee for an unsupported asset, '${params.asset_code}`,
       );
     }
+
     const { fee } = assetInfo;
     switch (fee.type) {
       case "none":

--- a/src/transfers/WithdrawProvider.ts
+++ b/src/transfers/WithdrawProvider.ts
@@ -34,7 +34,7 @@ import { TransferProvider } from "./TransferProvider";
  *
  * // show fee to user, confirm amount and destination
  *
- * const withdrawResult = await withdrawProvider.withdraw({
+ * const withdrawResult = await withdrawProvider.startWithdraw({
  *   type
  *   asset_code,
  *   dest,
@@ -77,12 +77,14 @@ export class WithdrawProvider extends TransferProvider {
   }
 
   /**
-   * Make a withdraw request.
+   * Start a withdraw request.
    *
    * Note that all arguments must be in snake_case (which is what transfer
    * servers expect)!
    */
-  public async withdraw(params: WithdrawRequest): Promise<TransferResponse> {
+  public async startWithdraw(
+    params: WithdrawRequest,
+  ): Promise<TransferResponse> {
     const isAuthRequired = this.getAuthStatus("withdraw", params.asset_code);
     const search = queryString.stringify({ ...params, account: this.account });
 
@@ -178,7 +180,7 @@ export class WithdrawProvider extends TransferProvider {
       case "pending":
         return Promise.reject(kycResult);
       case "success": {
-        const retryResponse = await this.withdraw(request);
+        const retryResponse = await this.startWithdraw(request);
         // Since we've just successfully KYC'd, the only expected response is
         // success. Reject anything else.
         if (retryResponse.type === "ok") {

--- a/src/transfers/WithdrawProvider.ts
+++ b/src/transfers/WithdrawProvider.ts
@@ -4,6 +4,7 @@ import {
   FetchKycInBrowserParams,
   TransferError,
   TransferResponse,
+  WithdrawAssetInfo,
   WithdrawAssetInfoMap,
   WithdrawRequest,
 } from "../types";
@@ -120,6 +121,21 @@ export class WithdrawProvider extends TransferProvider {
     });
 
     return withdraw;
+  }
+
+  /**
+   * Get one supported asset by code.
+   */
+  public getAsset(asset_code: string): WithdrawAssetInfo {
+    if (!this.info || !this.info[this.operation]) {
+      throw new Error(`Run fetchSupportedAssets before running getAsset!`);
+    }
+
+    if (!this.info[this.operation][asset_code]) {
+      throw new Error(`Asset not supported: ${asset_code}`);
+    }
+
+    return (this.info[this.operation] as WithdrawAssetInfoMap)[asset_code];
   }
 
   /**

--- a/src/transfers/WithdrawProvider.ts
+++ b/src/transfers/WithdrawProvider.ts
@@ -4,7 +4,7 @@ import {
   FetchKycInBrowserParams,
   TransferError,
   TransferResponse,
-  WithdrawInfo,
+  WithdrawAssetInfoMap,
   WithdrawRequest,
 } from "../types";
 
@@ -104,7 +104,7 @@ export class WithdrawProvider extends TransferProvider {
    * Fetch the assets that the deposit provider supports, along with details
    * about depositing that asset.
    */
-  public async fetchSupportedAssets(): Promise<WithdrawInfo> {
+  public async fetchSupportedAssets(): Promise<WithdrawAssetInfoMap> {
     const { withdraw } = await this.fetchInfo();
 
     // seed internal registry objects with supported assets

--- a/src/transfers/parseInfo.ts
+++ b/src/transfers/parseInfo.ts
@@ -1,12 +1,12 @@
 import {
-  DepositInfo,
+  DepositAssetInfoMap,
   Fee,
   Field,
   RawField,
   RawInfoResponse,
   RawType,
   SimpleFee,
-  WithdrawInfo,
+  WithdrawAssetInfoMap,
 } from "../types";
 
 function isValidInfoResponse(obj: any): obj is RawInfoResponse {
@@ -72,7 +72,7 @@ function parseField([fieldName, field]: FieldEntry): Field {
   };
 }
 
-export function parseWithdraw(info: RawInfoResponse): WithdrawInfo {
+export function parseWithdraw(info: RawInfoResponse): WithdrawAssetInfoMap {
   return Object.entries(info.withdraw).reduce(
     (accum, [asset_code, entry]) => {
       const fee = parseFee(entry, !!(info.fee && info.fee.enabled));
@@ -87,11 +87,11 @@ export function parseWithdraw(info: RawInfoResponse): WithdrawInfo {
       };
       return accum;
     },
-    {} as WithdrawInfo,
+    {} as WithdrawAssetInfoMap,
   );
 }
 
-export function parseDeposit(info: RawInfoResponse): DepositInfo {
+export function parseDeposit(info: RawInfoResponse): DepositAssetInfoMap {
   return Object.entries(info.deposit).reduce(
     (accum, [asset_code, entry]) => {
       const fee = parseFee(entry, !!(info.fee && info.fee.enabled));
@@ -106,6 +106,6 @@ export function parseDeposit(info: RawInfoResponse): DepositInfo {
       };
       return accum;
     },
-    {} as DepositInfo,
+    {} as DepositAssetInfoMap,
   );
 }

--- a/src/types/transfers.ts
+++ b/src/types/transfers.ts
@@ -205,6 +205,10 @@ export interface Field {
   choices?: string[];
 }
 
+export interface FieldPayload {
+  [name: string]: string;
+}
+
 export interface NoneFee {
   type: "none";
 }

--- a/src/types/transfers.ts
+++ b/src/types/transfers.ts
@@ -73,8 +73,8 @@ export interface RawType {
 }
 
 export interface Info {
-  withdraw: WithdrawInfo;
-  deposit: DepositInfo;
+  withdraw: WithdrawAssetInfoMap;
+  deposit: DepositAssetInfoMap;
   fee?: {
     enabled: boolean;
   };
@@ -95,7 +95,7 @@ export interface WithdrawAssetInfo {
   authentication_required?: boolean;
 }
 
-export interface WithdrawInfo {
+export interface WithdrawAssetInfoMap {
   [asset_code: string]: WithdrawAssetInfo;
 }
 
@@ -108,7 +108,7 @@ export interface DepositAssetInfo {
   authentication_required?: boolean;
 }
 
-export interface DepositInfo {
+export interface DepositAssetInfoMap {
   [asset_code: string]: DepositAssetInfo;
 }
 

--- a/src/types/transfers.ts
+++ b/src/types/transfers.ts
@@ -19,7 +19,7 @@ export interface FetchKycInBrowserParams<T> {
 export interface FeeParams {
   asset_code: string;
   amount: string;
-  type: string;
+  type: "none" | "simple" | "complex" | "SEPA" | "bank_account" | "cash";
 }
 
 export interface RawInfoResponse {

--- a/src/types/transfers.ts
+++ b/src/types/transfers.ts
@@ -19,7 +19,6 @@ export interface FetchKycInBrowserParams<T> {
 export interface FeeParams {
   asset_code: string;
   amount: string;
-  type: "none" | "simple" | "complex" | "SEPA" | "bank_account" | "cash";
 }
 
 export interface RawInfoResponse {


### PR DESCRIPTION
- Update the changelog
- Rename some types and functions for clarity
  - WithdrawInfo -> WithdrawAssetInfoMap
  - DepositInfo -> DepositAssetInfoMap
  - WithdrawProvider#withdraw -> #startWithdraw
  - DepositProvider#deposit -> #startDeposit
- Transfers: Fix fetchFinalFee parameters
- Transfers: Add `DepositProvider#validateFields` to validate deposit fields
- Transfers: Add `TransferProvider#getAssetInfo` to fetch single assets
