### PR TITLE
Fix URL manipulation in Transfers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 - Transfers: Add `TransferProvider#getAssetInfo` to fetch single assets
 - Transfers: If a deposit or withdraw requires auth and the interactive URL
   doesn't include a `jwt` property, add it
+- Transfers: Fix a bug in `getKycUrl` where the URL manipulation wouldn't take
+  into account certain URL shapes.
 
 ## [v0.0.6-rc.17](https://github.com/stellar/js-stellar-wallets/compare/v0.0.3-rc1...v0.0.6-rc.17)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/wallet-sdk",
-  "version": "0.0.7-rc.2",
+  "version": "0.0.7-rc.3",
   "description": "Libraries to help you write Stellar-enabled wallets in Javascript",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/transfers/DepositProvider.ts
+++ b/src/transfers/DepositProvider.ts
@@ -93,9 +93,9 @@ export class DepositProvider extends TransferProvider {
    */
   public async startDeposit(params: DepositRequest): Promise<TransferResponse> {
     const isAuthRequired = this.getAuthStatus("deposit", params.asset_code);
-    const search = queryString.stringify({ ...params, account: this.account });
+    const qs = queryString.stringify({ ...params, account: this.account });
 
-    const response = await fetch(`${this.transferServer}/deposit?${search}`, {
+    const response = await fetch(`${this.transferServer}/deposit?${qs}`, {
       headers: isAuthRequired ? this.getHeaders() : undefined,
     });
     const json = (await response.json()) as TransferResponse;
@@ -117,15 +117,11 @@ export class DepositProvider extends TransferProvider {
       json.url &&
       json.url.indexOf("jwt") === -1
     ) {
-      // tslint:disable-next-line prefer-const
-      let [url, hash] = json.url.split("#");
-      url = `${url}${url.indexOf("?") === -1 ? "?" : "&"}jwt=${this.authToken}`;
+      const { origin, pathname, search, hash } = new URL(json.url);
 
-      if (hash) {
-        url = `${url}#${hash}`;
-      }
-
-      json.url = url;
+      json.url = `${origin}${pathname}${search}${search ? "&" : "?"}jwt=${
+        this.authToken
+      }${hash}`;
     }
 
     return json;

--- a/src/transfers/WithdrawProvider.ts
+++ b/src/transfers/WithdrawProvider.ts
@@ -88,9 +88,9 @@ export class WithdrawProvider extends TransferProvider {
     params: WithdrawRequest,
   ): Promise<TransferResponse> {
     const isAuthRequired = this.getAuthStatus("withdraw", params.asset_code);
-    const search = queryString.stringify({ ...params, account: this.account });
+    const qs = queryString.stringify({ ...params, account: this.account });
 
-    const response = await fetch(`${this.transferServer}/withdraw?${search}`, {
+    const response = await fetch(`${this.transferServer}/withdraw?${qs}`, {
       headers: isAuthRequired ? this.getHeaders() : undefined,
     });
     const json = (await response.json()) as TransferResponse;
@@ -108,15 +108,11 @@ export class WithdrawProvider extends TransferProvider {
       json.url &&
       json.url.indexOf("jwt") === -1
     ) {
-      // tslint:disable-next-line prefer-const
-      let [url, hash] = json.url.split("#");
-      url = `${url}${url.indexOf("?") === -1 ? "?" : "&"}jwt=${this.authToken}`;
+      const { origin, pathname, search, hash } = new URL(json.url);
 
-      if (hash) {
-        url = `${url}#${hash}`;
-      }
-
-      json.url = url;
+      json.url = `${origin}${pathname}${search}${search ? "&" : "?"}jwt=${
+        this.authToken
+      }${hash}`;
     }
 
     return json;

--- a/src/transfers/getKycUrl.test.ts
+++ b/src/transfers/getKycUrl.test.ts
@@ -1,0 +1,94 @@
+import { TransferResponseType } from "../constants/transfers";
+import { getKycUrl } from "./getKycUrl";
+
+test("works properly on simple urls", () => {
+  expect(
+    getKycUrl({
+      request: {
+        amount: "2000",
+        asset_code: "test",
+      },
+      response: {
+        type: TransferResponseType.interactive_customer_info_needed,
+        url: "https://www.google.com",
+        id: "116",
+        interactive_deposit: true,
+      },
+      callback_url: "postMessage",
+    }),
+  ).toEqual("https://www.google.com/?callback=postMessage");
+});
+
+test("works properly on urls with directories", () => {
+  expect(
+    getKycUrl({
+      request: {
+        amount: "2000",
+        asset_code: "test",
+      },
+      response: {
+        type: TransferResponseType.interactive_customer_info_needed,
+        url: "https://www.google.com/mail",
+        id: "116",
+        interactive_deposit: true,
+      },
+      callback_url: "postMessage",
+    }),
+  ).toEqual("https://www.google.com/mail?callback=postMessage");
+});
+
+test("works properly on urls with querystrings", () => {
+  expect(
+    getKycUrl({
+      request: {
+        amount: "2000",
+        asset_code: "test",
+      },
+      response: {
+        type: TransferResponseType.interactive_customer_info_needed,
+        url: "https://www.google.com/?good=true",
+        id: "116",
+        interactive_deposit: true,
+      },
+      callback_url: "postMessage",
+    }),
+  ).toEqual("https://www.google.com/?good=true&callback=postMessage");
+});
+
+test("works properly on urls with querystrings and hashes", () => {
+  expect(
+    getKycUrl({
+      request: {
+        amount: "2000",
+        asset_code: "test",
+      },
+      response: {
+        type: TransferResponseType.interactive_customer_info_needed,
+        url: "https://www.google.com/?good=true#page=1",
+        id: "116",
+        interactive_deposit: true,
+      },
+      callback_url: "postMessage",
+    }),
+  ).toEqual("https://www.google.com/?good=true&callback=postMessage#page=1");
+});
+
+test("works properly on urls with everything", () => {
+  expect(
+    getKycUrl({
+      request: {
+        amount: "2000",
+        asset_code: "test",
+      },
+      response: {
+        type: TransferResponseType.interactive_customer_info_needed,
+        url: "https://www.google.com/mail/one?good=true#page=1",
+        id: "116",
+        interactive_deposit: true,
+      },
+      callback_url: "postMessage",
+    }),
+  ).toEqual(
+    "https://www.google.com/mail/one?good=true&callback=postMessage#page=1",
+  );
+});

--- a/src/transfers/getKycUrl.test.ts
+++ b/src/transfers/getKycUrl.test.ts
@@ -1,93 +1,56 @@
 import { TransferResponseType } from "../constants/transfers";
-import { getKycUrl } from "./getKycUrl";
+import { getKycUrl, KycUrlParams } from "./getKycUrl";
+
+function getParams(url: string, callback_url: string): KycUrlParams {
+  return {
+    request: {
+      amount: "2000",
+      asset_code: "test",
+    },
+    response: {
+      type: TransferResponseType.interactive_customer_info_needed,
+      url,
+      id: "116",
+      interactive_deposit: true,
+    },
+    callback_url,
+  };
+}
 
 test("works properly on simple urls", () => {
-  expect(
-    getKycUrl({
-      request: {
-        amount: "2000",
-        asset_code: "test",
-      },
-      response: {
-        type: TransferResponseType.interactive_customer_info_needed,
-        url: "https://www.google.com",
-        id: "116",
-        interactive_deposit: true,
-      },
-      callback_url: "postMessage",
-    }),
-  ).toEqual("https://www.google.com/?callback=postMessage");
+  expect(getKycUrl(getParams("https://www.google.com", "postMessage"))).toEqual(
+    "https://www.google.com/?callback=postMessage",
+  );
 });
 
 test("works properly on urls with directories", () => {
   expect(
-    getKycUrl({
-      request: {
-        amount: "2000",
-        asset_code: "test",
-      },
-      response: {
-        type: TransferResponseType.interactive_customer_info_needed,
-        url: "https://www.google.com/mail",
-        id: "116",
-        interactive_deposit: true,
-      },
-      callback_url: "postMessage",
-    }),
+    getKycUrl(getParams("https://www.google.com/mail", "postMessage")),
   ).toEqual("https://www.google.com/mail?callback=postMessage");
 });
 
 test("works properly on urls with querystrings", () => {
   expect(
-    getKycUrl({
-      request: {
-        amount: "2000",
-        asset_code: "test",
-      },
-      response: {
-        type: TransferResponseType.interactive_customer_info_needed,
-        url: "https://www.google.com/?good=true",
-        id: "116",
-        interactive_deposit: true,
-      },
-      callback_url: "postMessage",
-    }),
+    getKycUrl(getParams("https://www.google.com?good=true", "postMessage")),
   ).toEqual("https://www.google.com/?good=true&callback=postMessage");
 });
 
 test("works properly on urls with querystrings and hashes", () => {
   expect(
-    getKycUrl({
-      request: {
-        amount: "2000",
-        asset_code: "test",
-      },
-      response: {
-        type: TransferResponseType.interactive_customer_info_needed,
-        url: "https://www.google.com/?good=true#page=1",
-        id: "116",
-        interactive_deposit: true,
-      },
-      callback_url: "postMessage",
-    }),
+    getKycUrl(
+      getParams("https://www.google.com/?good=true#page=1", "postMessage"),
+    ),
   ).toEqual("https://www.google.com/?good=true&callback=postMessage#page=1");
 });
 
 test("works properly on urls with everything", () => {
   expect(
-    getKycUrl({
-      request: {
-        amount: "2000",
-        asset_code: "test",
-      },
-      response: {
-        type: TransferResponseType.interactive_customer_info_needed,
-        url: "https://www.google.com/mail/one?good=true#page=1",
-        id: "116",
-        interactive_deposit: true,
-      },
-      callback_url: "postMessage",
-    }),
+    getKycUrl(
+      getParams(
+        "https://www.google.com/mail/one?good=true#page=1",
+        "postMessage",
+      ),
+    ),
   ).toEqual(
     "https://www.google.com/mail/one?good=true&callback=postMessage#page=1",
   );

--- a/src/transfers/getKycUrl.ts
+++ b/src/transfers/getKycUrl.ts
@@ -53,18 +53,24 @@ const isPostMessage = (params: KycUrlParams): params is PostMessageParams =>
  * @returns {string} A URL to open so users can complete their KYC information.
  */
 export function getKycUrl(params: KycUrlParams) {
+  // break apart and re-produce the URL
+  const { origin, pathname, search, hash } = new URL(params.response.url);
+
+  let callback;
+
   if (isPostMessage(params)) {
-    return `${params.response.url}&callback=postMessage`;
+    callback = "postMessage";
   } else {
     // If the callback arg is a URL, add the original request to it as a
     // querystring argument.
     const url = new URL(params.callback_url);
-    const search = { ...queryString.parse(url.search) };
-    search.request = encodeURIComponent(JSON.stringify(params.request));
-    url.search = queryString.stringify(search);
-
-    return `${params.response.url}&callback=${encodeURIComponent(
-      url.toString(),
-    )}`;
+    const newParams = { ...queryString.parse(url.search) };
+    newParams.request = encodeURIComponent(JSON.stringify(params.request));
+    url.search = queryString.stringify(newParams);
+    callback = encodeURIComponent(url.toString());
   }
+
+  return `${origin}${pathname}${search}${
+    search ? "&" : "?"
+  }callback=${callback}${hash}`;
 }


### PR DESCRIPTION
- Fix a bug and add tests where `getKycUrl` wouldn't validly manipulate URLs without querystring params, or with hash params
- Use `new URL` to inject JWTs instead of manually searching for the hash