### PR TITLE
Unfunded account detection

### DIFF
--- a/src/data/DataProvider.ts
+++ b/src/data/DataProvider.ts
@@ -111,7 +111,7 @@ export class DataProvider {
       await this.fetchAccountDetails();
       return true;
     } catch (e) {
-      return !!e.isUnfunded;
+      return !e.isUnfunded;
     }
   }
 
@@ -289,9 +289,9 @@ export class DataProvider {
           this._watcherTimeouts.watchPayments = setTimeout(() => {
             this.watchPayments(params);
           }, 2000);
-        } else {
-          onError(err);
         }
+
+        onError(err);
       });
 
     // if they exec this function, don't make the balance callback do anything

--- a/src/data/DataProvider.ts
+++ b/src/data/DataProvider.ts
@@ -228,9 +228,9 @@ export class DataProvider {
           this._watcherTimeouts.watchAccountDetails = setTimeout(() => {
             this.watchAccountDetails(params);
           }, 2000);
-        } else {
-          onError(err);
         }
+
+        onError(err);
       });
 
     // if they exec this function, don't make the balance callback do anything


### PR DESCRIPTION
- Always throw an error in watchers when we find out the account is unfunded. Those errors will have a property `isUnfunded` set to true so you can distinguish them from other errors.
- Fix a bug where `DataProvider#isAccountFunded` was returning flipped results.