### PR TITLE
URL + Transfers

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
     "query-string": "^6.4.2",
     "scrypt-async": "^2.0.1",
     "tweetnacl": "^1.0.1",
-    "tweetnacl-util": "^0.15.0",
-    "url": "^0.11.0"
+    "tweetnacl-util": "^0.15.0"
   }
 }

--- a/src/transfers/fetchKycInBrowser.ts
+++ b/src/transfers/fetchKycInBrowser.ts
@@ -1,7 +1,7 @@
 import {
   DepositRequest,
   FetchKycInBrowserParams,
-  KycPromptStatus,
+  KycStatus,
   WithdrawRequest,
 } from "../types";
 
@@ -9,7 +9,7 @@ import { getKycUrl } from "./getKycUrl";
 
 export function fetchKycInBrowser(
   params: FetchKycInBrowserParams<DepositRequest | WithdrawRequest>,
-): Promise<KycPromptStatus> {
+): Promise<KycStatus> {
   const { response, window: windowContext } = params;
   const { origin } = new URL(response.url);
   return new Promise((resolve, reject) => {

--- a/src/transfers/getKycUrl.ts
+++ b/src/transfers/getKycUrl.ts
@@ -1,5 +1,4 @@
 import queryString from "query-string";
-import { URL } from "url";
 
 import {
   DepositRequest,

--- a/src/types/transfers.ts
+++ b/src/types/transfers.ts
@@ -181,19 +181,14 @@ export interface InteractiveKycNeededResponse extends TransferResponse {
   interactive_deposit?: boolean;
 }
 
-export interface KycStatus extends TransferResponse {
+export interface AnchorUSDKycStatus extends TransferResponse {
   type: TransferResponseType.customer_info_status;
+  status: "success" | "pending" | "denied";
   more_info_url?: string;
   eta?: number;
 }
 
-export interface CustomerInfoStatus extends KycStatus {
-  status: "pending" | "denied";
-}
-
-export interface KycPromptStatus extends KycStatus {
-  status: "success" | "pending" | "denied";
-}
+export type KycStatus = AnchorUSDKycStatus | Transaction;
 
 export interface WithdrawType {
   name: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4516,11 +4516,6 @@ pump@^3.0.0:
     end-of-stream "^1.1.0"
     once "^1.3.1"
 
-punycode@1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
-  integrity sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=
-
 punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
@@ -4544,11 +4539,6 @@ query-string@^6.4.2:
     decode-uri-component "^0.2.0"
     split-on-first "^1.0.0"
     strict-uri-encode "^2.0.0"
-
-querystring@0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
-  integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
 
 querystringify@^2.1.1:
   version "2.1.1"
@@ -5674,14 +5664,6 @@ url-parse@^1.4.3:
   dependencies:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
-
-url@^0.11.0:
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/url/-/url-0.11.0.tgz#3838e97cfc60521eb73c525a8e55bfdd9e2e28f1"
-  integrity sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=
-  dependencies:
-    punycode "1.3.2"
-    querystring "0.2.0"
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
- Use the native URL constructor instead of a package
- Add support for canonical SEP-24 transaction responses in fetchKycInBrowser
- Enable `getKycUrl` to be called without a callback
- Add `getKycUrl` to TransferProvider
- `fetchKycInBrowser` and `getKycUrl` no longer need to be explicitly passed request and response; it'll read the stored values from the class.