### PR TITLE
added a webpack compiler for commonjs output

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "stellar-sdk": "^3.x.x"
   },
   "scripts": {
+    "prepare": "yarn build ; yarn build:commonjs",
     "build": "tsc -p tsconfig.json",
+    "build:commonjs": "webpack --mode production",
     "dev": "tsc-watch --project tsconfig.json --onSuccess 'yarn lint'",
     "docs": "typedoc",
     "lint": "tslint --fix --format verbose --project tsconfig.json",
@@ -50,6 +52,7 @@
     "@types/ledgerhq__hw-transport-u2f": "^4.21.1",
     "@types/sinon": "^7.0.11",
     "babel-jest": "^24.5.0",
+    "babel-loader": "^8.0.6",
     "concurrently": "^4.1.1",
     "husky": "^1.3.1",
     "jest": "^24.7.1",
@@ -57,13 +60,18 @@
     "jest-mock-random": "^1.0.3",
     "lint-staged": "^8.1.5",
     "prettier": "^1.17.0",
-    "regenerator-runtime": "^0.13.2",
+    "regenerator-runtime": "^0.13.3",
     "sinon": "^7.3.1",
     "stellar-sdk": "^3.2.0",
+    "terser-webpack-plugin": "^2.3.0",
+    "ts-loader": "^6.2.1",
     "tsc-watch": "^2.1.2",
     "tslint": "^5.14.0",
     "typedoc": "^0.14.2",
-    "typescript": "^3.3.3333"
+    "typescript": "^3.3.3333",
+    "webpack": "^4.41.2",
+    "webpack-cli": "^3.3.10",
+    "path": "^0.12.7"
   },
   "dependencies": {
     "@ledgerhq/hw-app-str": "^4.48.0",

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1,0 +1,2 @@
+import "regenerator-runtime/runtime";
+export * from "./index";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
   "exclude": [
     "node_modules",
     "dist",
+    "src/browser.ts",
     "playground/src/@stellar",
     "documentation/src/docs.json",
     "src/fixtures"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,56 @@
+const path = require("path");
+const webpack = require("webpack");
+const TerserPlugin = require("terser-webpack-plugin");
+
+module.exports = {
+  entry: {
+    "wallet-sdk": "./src/browser.ts",
+    "wallet-sdk.min": "./src/browser.ts",
+  },
+  output: {
+    filename: "[name].js",
+    path: path.resolve(__dirname, "dist/commonjs"),
+    libraryTarget: "commonjs-module",
+  },
+  resolve: {
+    extensions: [".js", ".json", ".ts"],
+  },
+  module: {
+    rules: [
+      {
+        test: /\.ts$/,
+        exclude: /node_modules/,
+        use: [
+          {
+            loader: "ts-loader",
+            options: {
+              transpileOnly: true,
+            },
+          },
+        ],
+      },
+      {
+        test: /\.js$/,
+        exclude: /node_modules\/(?!(crc)\/).*/,
+        use: [
+          {
+            loader: "babel-loader",
+          },
+        ],
+      },
+    ],
+  },
+  plugins: [
+    new webpack.optimize.LimitChunkCountPlugin({
+      maxChunks: 1,
+    }),
+  ],
+  optimization: {
+    minimize: true,
+    minimizer: [
+      new TerserPlugin({
+        test: /\.min\.js$/,
+      }),
+    ],
+  },
+};


### PR DESCRIPTION
So I have this issue when using the standard `import WalletSdk from '@stellar/wallet-sdk'` with component toolchains. Specifically Stencil though I would imagine it would hold true for Polymer, Svelte, etc. as well. It's a very strange issue with the circular imports across all the Stellar libraries `js-xdr`, `stellar-base` and `stellar-sdk`. I spent a ton of time trying to track down the issue but ultimately had to settle for compiling the library as a `commonjs-module`. I've added a PR including this build option to the sdk, base and wallet repos.

In this case as part of the publish package command the `"build:commonjs": "webpack --mode production"` will compile a `commonjs/wallet-sdk.js` file in the `dist/` folder.

You can then require it like `import WalletSdk from '@stellar/wallet-sdk/dist/commonjs/wallet-sdk'`

This solves the issue as the library is all complied rather than trying to tree shake or order the require chain.

Ultimately not sure if this is the best answer vs fixing or finding the actual issue but it's a clean solution for now, especially for modern browser builds which don't want to include external browser scripts.

If you'd like to take a stab at the original problem, pull this repo https://github.com/tyvdh/stellar-demo-wallet, run `npm i ; npm start` and inspect the console for the error.