### PR TITLE
Support language codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
   transfer-related fetches.
 - [Transfers] Make the transactions fetcher more resilient to invalid responses
   from /transactions.
+- [Transfers] `DepositProvider` and `WithdrawProvider` instantiation now takes a
+  third, optional parameter for
+  [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1) language codes. The
+  default value is "en".
 
 ## [v0.0.9-rc.1](https://github.com/stellar/js-stellar-wallets/compare/v0.0.8-rc.1...v0.0.9-rc.1)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/wallet-sdk",
-  "version": "0.0.9-rc.4",
+  "version": "0.0.9-rc.5",
   "description": "Libraries to help you write Stellar-enabled wallets in Javascript",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/transfers/DepositProvider.ts
+++ b/src/transfers/DepositProvider.ts
@@ -90,8 +90,12 @@ export class DepositProvider extends TransferProvider {
   public response?: TransferResponse;
   public request?: DepositRequest;
 
-  constructor(transferServer: string, account: string) {
-    super(transferServer, account, "deposit");
+  constructor(
+    transferServer: string,
+    account: string,
+    language: string = "en",
+  ) {
+    super(transferServer, account, language, "deposit");
   }
 
   /**
@@ -119,6 +123,8 @@ export class DepositProvider extends TransferProvider {
       Object.keys(request).forEach((key: string) => {
         body.append(key, request[key]);
       });
+
+      body.append("lang", this.language);
 
       response = await fetch(
         `${this.transferServer}/transactions/deposit/interactive`,

--- a/src/transfers/TransferProvider.ts
+++ b/src/transfers/TransferProvider.ts
@@ -68,6 +68,7 @@ export abstract class TransferProvider {
   public transferServer: string;
   public operation: "deposit" | "withdraw";
   public account: string;
+  public language: string;
   public info?: Info;
   public authToken?: string;
 
@@ -85,6 +86,7 @@ export abstract class TransferProvider {
   constructor(
     transferServer: string,
     account: string,
+    language: string,
     operation: "deposit" | "withdraw",
   ) {
     if (!transferServer) {
@@ -103,6 +105,7 @@ export abstract class TransferProvider {
     this.transferServer = transferServer.replace(/\/$/, "");
     this.operation = operation;
     this.account = account;
+    this.language = language;
 
     this._watchOneTransactionRegistry = {};
     this._watchAllTransactionsRegistry = {};
@@ -112,7 +115,9 @@ export abstract class TransferProvider {
   }
 
   protected async fetchInfo(): Promise<Info> {
-    const response = await fetch(`${this.transferServer}/info`);
+    const response = await fetch(
+      `${this.transferServer}/info?lang=${this.language}`,
+    );
 
     if (!response.ok) {
       try {

--- a/src/transfers/WithdrawProvider.ts
+++ b/src/transfers/WithdrawProvider.ts
@@ -83,8 +83,12 @@ export class WithdrawProvider extends TransferProvider {
   public response?: TransferResponse;
   public request?: WithdrawRequest;
 
-  constructor(transferServer: string, account: string) {
-    super(transferServer, account, "withdraw");
+  constructor(
+    transferServer: string,
+    account: string,
+    language: string = "en",
+  ) {
+    super(transferServer, account, language, "withdraw");
   }
 
   /**
@@ -112,6 +116,8 @@ export class WithdrawProvider extends TransferProvider {
       Object.keys(request).forEach((key: string) => {
         body.append(key, request[key]);
       });
+
+      body.append("lang", this.language);
 
       response = await fetch(
         `${this.transferServer}/transactions/withdraw/interactive`,


### PR DESCRIPTION
[Transfers] `DepositProvider` and `WithdrawProvider` instantiation now takes a third, optional parameter for [ISO 639-1](https://en.wikipedia.org/wiki/ISO_639-1) language codes. The default value is "en".

See also:
https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0024.md#request
https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0024.md#request-1
https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0024.md#request-2