### PR TITLE
Account wiper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## In master
 
+## [v0.1.0-rc.1](https://github.com/stellar/js-stellar-wallets/compare/v0.0.9-rc.1...v0.1.0-rc.1)
+
 **Breaking changes**:
 
 - Upgraded `stellar-sdk` to 5.0.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,20 @@
 
 ## In master
 
+**Breaking changes**:
+
+- Upgraded `stellar-sdk` to 5.0.0.
+- [DataProvider] Constructor now requires a `networkPassphrase` param.
+
+Other changes:
+
 - When parsing API responses, take extra care making sure that the responses are
   valid JSON, and throw if not.
 - [DataProvider] Add memo information to payments.
+- [DataProvider] Add `DataProvider#getStripAndMergeAccountTransaction`, a
+  function that makes it easier to merge accounts with no balances but
+  trustlines, outstanding offers, etc. Returns a transaction to strip and merge
+  the account into another.
 - [KeyManager] Correctly handle non-successful HTTP status codes when fetching
   auth tokens.
 - [KeyManager] fetchAuthToken now accepts another account, if you're trying to

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/wallet-sdk",
-  "version": "0.0.9-rc.9",
+  "version": "0.1.0-rc.1",
   "description": "Libraries to help you write Stellar-enabled wallets in Javascript",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
     "@ledgerhq/hw-app-str": "^4.48.0",
     "@ledgerhq/hw-transport-u2f": "^4.48.0",
     "@types/jest": "^24.0.11",
-    "@types/stellar-base": "^0.10.2",
     "change-case": "^3.1.0",
     "lodash": "^4.17.14",
     "query-string": "^6.4.2",

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   "license": "Apache-2.0",
   "prettier": "@stellar/prettier-config",
   "peerDependencies": {
-    "stellar-sdk": "^3.x.x",
-    "bignumber.js": "*"
+    "bignumber.js": "*",
+    "stellar-sdk": "^5.x.x"
   },
   "scripts": {
     "prepare": "yarn build ; yarn build:commonjs",
@@ -63,10 +63,11 @@
     "jest-mock-random": "^1.0.3",
     "lint-staged": "^8.1.5",
     "node-localstorage": "^2.1.5",
+    "path": "^0.12.7",
     "prettier": "^1.17.0",
     "regenerator-runtime": "^0.13.3",
     "sinon": "^7.3.1",
-    "stellar-sdk": "^3.2.0",
+    "stellar-sdk": "^5.0.0",
     "terser-webpack-plugin": "^2.3.0",
     "ts-loader": "^6.2.1",
     "tsc-watch": "^2.1.2",
@@ -74,8 +75,7 @@
     "typedoc": "^0.14.2",
     "typescript": "^3.3.3333",
     "webpack": "^4.41.2",
-    "webpack-cli": "^3.3.10",
-    "path": "^0.12.7"
+    "webpack-cli": "^3.3.10"
   },
   "dependencies": {
     "@ledgerhq/hw-app-str": "^4.48.0",

--- a/playground/package.json
+++ b/playground/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@stellar/elements": "^0.0.0",
+    "big.js": "^5.2.2",
     "lodash": "^4.17.14",
     "moment": "^2.24.0",
     "react": "^16.8.5",
@@ -29,6 +30,6 @@
     "not op_mini all"
   ],
   "devDependencies": {
-    "styled-components": "^4.2.0"
+    "styled-components": "^5.1.0"
   }
 }

--- a/playground/package.json
+++ b/playground/package.json
@@ -12,7 +12,7 @@
     "react-json-view": "^1.19.1",
     "react-router-dom": "^5.1.2",
     "react-scripts": "^3.1.1",
-    "stellar-sdk": "^2.3.0"
+    "stellar-sdk": "^5.0.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/playground/src/App.js
+++ b/playground/src/App.js
@@ -3,7 +3,7 @@ import { BrowserRouter as Router, Switch, Route, Link } from "react-router-dom";
 import styled from "styled-components";
 import { GlobalStyle } from "@stellar/elements";
 import * as WalletSdk from "@stellar/wallet-sdk";
-import StellarSdk from "stellar-sdk";
+import StellarSdk, { Networks } from "stellar-sdk";
 
 import AccountDetails from "components/AccountDetails";
 import KeyEntry from "components/KeyEntry";
@@ -36,6 +36,7 @@ class App extends Component {
         ? "https://horizon-testnet.stellar.org/"
         : "https://horizon.stellar.org",
       accountOrKey: publicKey,
+      networkPassphrase: isTestnet ? Networks.TESTNET : Networks.PUBLIC,
     });
 
     this.setState({

--- a/playground/src/App.js
+++ b/playground/src/App.js
@@ -1,6 +1,5 @@
 import React, { Component } from "react";
 import { BrowserRouter as Router, Switch, Route, Link } from "react-router-dom";
-import styled from "styled-components";
 import { GlobalStyle } from "@stellar/elements";
 import * as WalletSdk from "@stellar/wallet-sdk";
 import StellarSdk, { Networks } from "stellar-sdk";
@@ -11,12 +10,6 @@ import Offers from "components/Offers";
 import Trades from "components/Trades";
 import Payments from "components/Payments";
 import TransferProvider from "components/TransferProvider";
-
-const El = styled.div`
-  display: flex;
-  font-size: 0.8em;
-  line-height: 1.2em;
-`;
 
 class App extends Component {
   state = {

--- a/playground/src/components/AccountDetails.js
+++ b/playground/src/components/AccountDetails.js
@@ -1,5 +1,8 @@
 import React, { Component } from "react";
 import Json from "react-json-view";
+import { Keypair } from "stellar-sdk";
+
+import TransactionViewer from "components/TransactionViewer";
 
 class AccountDetails extends Component {
   state = {
@@ -8,6 +11,7 @@ class AccountDetails extends Component {
     updateTimes: [],
     streamEnder: null,
     isAccountFunded: null,
+    mergeTransaction: null,
   };
 
   componentDidMount() {
@@ -71,10 +75,32 @@ class AccountDetails extends Component {
   };
 
   render() {
-    const { accountDetails, err, updateTimes, isAccountFunded } = this.state;
+    const {
+      accountDetails,
+      err,
+      updateTimes,
+      isAccountFunded,
+      mergeTransaction,
+    } = this.state;
+
+    const handleGetTransaction = async () => {
+      const trans = await this.props.dataProvider.getStripAndMergeAccountTransaction(
+        Keypair.random().publicKey(),
+      );
+      console.log("~!!!!!!!!!!! rans: ", trans);
+      debugger;
+      this.setState({ mergeTransaction: trans });
+    };
+
     return (
       <div>
         <h2>Account Details</h2>
+
+        <button onClick={handleGetTransaction}>Run merge command</button>
+
+        {mergeTransaction && (
+          <TransactionViewer transaction={mergeTransaction} />
+        )}
 
         {!isAccountFunded && <p>Account isn't funded yet.</p>}
         {isAccountFunded && (

--- a/playground/src/components/OperationViewer.js
+++ b/playground/src/components/OperationViewer.js
@@ -204,7 +204,7 @@ const OperationViewer = ({ type, ...props }) => {
 
       {type === TYPE.changeTrust && (
         <p>
-          {props.limit === "0" ? (
+          {parseInt(props.limit, 10) === 0 ? (
             <>
               Remove trustline to {props.line.code} ({props.line.issuer})
             </>

--- a/playground/src/components/OperationViewer.js
+++ b/playground/src/components/OperationViewer.js
@@ -1,0 +1,313 @@
+import React, { Fragment } from "react";
+import PropTypes from "prop-types";
+import styled from "styled-components";
+import Big from "big.js";
+
+export const LUMENAUT_INFLATION_DESTINATION =
+  "GCCD6AJOYZCUAQLX32ZJF2MKFFAUJ53PVCFQI3RHWKL3V47QYE2BNAUT";
+
+export const RECOGNIZED_DESTINATIONS = {
+  GDCHDRSDOBRMSUDKRE2C4U4KDLNEATJPIHHR2ORFL5BSD56G4DQXL4VW: "StellarTerm",
+};
+
+export const MEMO_TYPES = {
+  none: "none",
+  text: "text",
+  id: "id",
+  hash: "hash",
+  return: "return",
+};
+
+export const DESTINATION_NEEDS_MEMO = {
+  // These ones we figured out ourselves.
+  GASWJWFRYE55KC7MGANZMMRBK5NPXT3HMPDQ6SEXZN6ZPWYXVVYBFRTE: {
+    name: "AnchorUSD",
+    requiredMemoType: MEMO_TYPES.hash,
+  },
+
+  // List of destinations pulled from StellarTerm's directory.json
+  // https://raw.githubusercontent.com/stellarterm/stellarterm/master/directory/directory.json
+  GCEGERI7COJYNNID6CYSKS5DPPLGCCLPTOSCDD2LG5SJIVWM5ISUPERI: {
+    name: "Superlumen Issuer",
+    requiredMemoType: MEMO_TYPES.id,
+  },
+  GA5XIGA5C7QTPTWXQHY6MCJRMTRZDOSHR6EFIBNDQTCQHG262N4GGKTM: {
+    name: "Kraken",
+    requiredMemoType: MEMO_TYPES.id,
+    acceptedAssets: ["native"],
+  },
+  GCGNWKCJ3KHRLPM3TM6N7D3W5YKDJFL6A2YCXFXNMRTZ4Q66MEMZ6FI2: {
+    name: "Poloniex",
+    requiredMemoType: MEMO_TYPES.id,
+    acceptedAssets: ["native"],
+  },
+  GB6YPGW5JFMMP2QB2USQ33EUWTXVL4ZT5ITUNCY3YKVWOJPP57CANOF3: {
+    name: "Bittrex",
+    requiredMemoType: MEMO_TYPES.text,
+    acceptedAssets: ["native"],
+  },
+  GB7GRJ5DTE3AA2TCVHQS2LAD3D7NFG7YLTOEWEBVRNUUI2Q3TJ5UQIFM: {
+    name: "BTC38",
+    requiredMemoType: MEMO_TYPES.id,
+  },
+  GBV4ZDEPNQ2FKSPKGJP2YKDAIZWQ2XKRQD4V4ACH3TCTFY6KPY3OAVS7: {
+    name: "Changelly",
+    requiredMemoType: MEMO_TYPES.id,
+  },
+  GBR3RS2Z277FER476OFHFXQJRKYSQX4Z7XNWO65AN3QPRUANUASANG3L: {
+    name: "PapayaBot",
+    requiredMemoType: MEMO_TYPES.text,
+  },
+  GBTBVILDGCOIK26EPEHYCMKM7J5MTQ4FD5DO37GVTTBP45TVGRAROQHP: {
+    name: "KOINEX",
+    requiredMemoType: MEMO_TYPES.id,
+    acceptedAssets: ["native"],
+  },
+  GBGVRE5DH6HGNYNLWQITKRQYGR4PWQEH6MOE5ELPY3I4XJPTZ7CVT4YW: {
+    name: "PapayaSwap",
+    requiredMemoType: MEMO_TYPES.text,
+  },
+  GBQWA6DU6OXHH4AVTFCONQ76LHEWQVZAW7SFSW4PPCAI2NX4MJDZUYDW: {
+    name: "Piiko",
+    requiredMemoType: MEMO_TYPES.text,
+  },
+  GBKTJSNUSR6OCXA5WDWGT33MNSCNQHOBQUBYC7TVS7BOXDKWFNHI4QNH: {
+    name: "Exrates",
+    requiredMemoType: MEMO_TYPES.text,
+    acceptedAssets: ["native"],
+  },
+  GC4KAS6W2YCGJGLP633A6F6AKTCV4WSLMTMIQRSEQE5QRRVKSX7THV6S: {
+    name: "Indodax",
+    requiredMemoType: MEMO_TYPES.text,
+    acceptedAssets: ["native"],
+  },
+  GCO2IP3MJNUOKS4PUDI4C7LGGMQDJGXG3COYX3WSB4HHNAHKYV5YL3VC: {
+    name: "Binance",
+    requiredMemoType: MEMO_TYPES.id,
+    acceptedAssets: ["native"],
+  },
+  GAHK7EEG2WWHVKDNT4CEQFZGKF2LGDSW2IVM4S5DP42RBW3K6BTODB4A: {
+    name: "Binance",
+    requiredMemoType: MEMO_TYPES.id,
+    acceptedAssets: ["native"],
+  },
+  GBOEEVARKVASOQSSXCAHNTGJTVALJE2QM3AQQ2K3VXACQ6JJREQRJZKB: {
+    name: "OKEX",
+    requiredMemoType: MEMO_TYPES.id,
+    acceptedAssets: ["native"],
+  },
+  GDZCEWJ5TVXUTFH6V5CVDQDE43KRXYUFRHKI7X64EWMVOVYYZJFWIFQ2: {
+    name: "AEX",
+    requiredMemoType: MEMO_TYPES.id,
+    acceptedAssets: ["native"],
+  },
+  GCXDR4QZ4OTVX6433DPTXELCSEWQ4E5BIPVRRJMUR6M3NT4JCVIDALZO: {
+    name: "GOPAX",
+    requiredMemoType: MEMO_TYPES.text,
+  },
+  GBZ35ZJRIKJGYH5PBKLKOZ5L6EXCNTO7BKIL7DAVVDFQ2ODJEEHHJXIM: {
+    name: "XIM",
+    acceptedAssets: ["native"],
+  },
+  GCZYLNGU4CA5NAWBAVTHMZH4JXWKP2OUJ6OK3I7XXZCNA5622WUJVLTG: {
+    name: "RMT swap",
+    acceptedAssets: [
+      "RMT:GCVWTTPADC5YB5AYDKJCTUYSCJ7RKPGE4HT75NIZOUM4L7VRTS5EKLFN",
+    ],
+  },
+  GBVUDZLMHTLMZANLZB6P4S4RYF52MVWTYVYXTQ2EJBPBX4DZI2SDOLLY: {
+    name: "Pedity Issuer",
+  },
+  GA6HCMBLTZS5VYYBCATRBRZ3BZJMAFUDKYYF6AH6MVCMGWMRDNSWJPIH: {
+    name: "Mobius Issuer",
+  },
+  GDCHDRSDOBRMSUDKRE2C4U4KDLNEATJPIHHR2ORFL5BSD56G4DQXL4VW: {
+    name: "StellarTerm Inflation",
+  },
+  GCCD6AJOYZCUAQLX32ZJF2MKFFAUJ53PVCFQI3RHWKL3V47QYE2BNAUT: {
+    name: "Lumenaut Inflation",
+  },
+  GBTCBCWLE6YVTR5Y5RRZC36Z37OH22G773HECWEIZTZJSN4WTG3CSOES: {
+    name: "NaoBTC",
+    acceptedAssets: [
+      "BTC:GATEMHCCKCY67ZUCKTROYN24ZYT5GK4EQZ65JJLDHKHRUZI3EUEKMTCH",
+    ],
+  },
+  GDRSWSKJCIB6Z65UA7W5RG62A7M5K3A5IHMED6DYHLPLWLVQCOOGDQ7S: {
+    name: "Gate.io",
+    requiredMemoType: MEMO_TYPES.id,
+  },
+
+  // From https://api.blockeq.com/directory/exchanges
+  // Retrieved (and deduped/stripped) 2018-09-28
+  GAWPTHY6233GRWZZ7JXDMVXDUDCVQVVQ2SXCSTG3R3CNP5LQPDAHNBKL: {
+    name: "Bitfinex",
+    requiredMemoType: MEMO_TYPES.text,
+  },
+  GB3RMPTL47E4ULVANHBNCXSXM2ZA5JFY5ISDRERPCXNJUDEO73QFZUNK: {
+    name: "CEX.io",
+    requiredMemoType: MEMO_TYPES.id,
+  },
+  GCKMUBVVU4VWUTIWJ3VHGGUTE2EVRIHW4HD5XMTTN5X2DVT5SAZ7MA4T: {
+    name: "CoinEgg",
+    requiredMemoType: MEMO_TYPES.id,
+  },
+  GCLDH6L6FBLTD3H3B23D6TIFVVTFBLZMNBC3ZOI6FGI5GPQROL4FOXIN: {
+    name: "RippleFox",
+    requiredMemoType: MEMO_TYPES.id,
+  },
+};
+const El = styled.div`
+  padding: 10px 0;
+
+  &:last-of-type {
+    border: none;
+  }
+`;
+
+const TitleEl = styled.h3`
+  font-size: 16px;
+`;
+
+const TYPE = {
+  changeTrust: "changeTrust",
+  manageOffer: "manageOffer",
+  setOptions: "setOptions",
+  createAccount: "createAccount",
+  payment: "payment",
+  // pathPayment: "pathPayment",
+};
+
+const TYPE_LABEL = {
+  [TYPE.changeTrust]: `Trustline Change`,
+  [TYPE.manageOffer]: `Manage Offer`,
+  [TYPE.setOptions]: `Set Network Options`,
+  [TYPE.createAccount]: `Fund a New Account`,
+  [TYPE.payment]: `Make a Payment`,
+  // [TYPE.pathPayment]: `Make a Path Payment`,
+};
+
+const OperationViewer = ({ type, ...props }) => {
+  let knownAccountName;
+
+  if (type === TYPE.setOptions && props.inflationDest) {
+    if (DESTINATION_NEEDS_MEMO[props.inflationDest]) {
+      knownAccountName = DESTINATION_NEEDS_MEMO[props.inflationDest].name;
+    } else if (RECOGNIZED_DESTINATIONS[props.inflationDest]) {
+      knownAccountName = RECOGNIZED_DESTINATIONS[props.inflationDest];
+    }
+  }
+
+  return (
+    <El>
+      <TitleEl>{TYPE_LABEL[type] || type}</TitleEl>
+
+      {type === TYPE.changeTrust && (
+        <p>
+          {props.limit === "0" ? (
+            <>
+              Remove trustline to {props.line.code} ({props.line.issuer})
+            </>
+          ) : (
+            <>
+              Add trustline to {props.line.code} ({props.line.issuer})
+            </>
+          )}
+        </p>
+      )}
+
+      {type === TYPE.manageOffer && (
+        <Fragment>
+          {props.selling.code === "REMOVE" ? (
+            <p>
+              <>Cancel offer #{props.offerId}</>
+            </p>
+          ) : (
+            <p>
+              <>
+                Make a new offer, giving {props.amount} {props.selling.code} for{" "}
+                {Big(props.amount)
+                  .times(props.price)
+                  .toPrecision(7)}
+                {props.buying.code}
+              </>
+            </p>
+          )}
+        </Fragment>
+      )}
+
+      {type === TYPE.setOptions && (
+        <Fragment>
+          {props.inflationDest && (
+            <p>
+              {props.inflationDest === LUMENAUT_INFLATION_DESTINATION && (
+                <>
+                  Set your inflation destination to Lumenauts Inflation Pool and
+                  get weekly airdrops into your account.
+                </>
+              )}
+              {knownAccountName && (
+                <>
+                  Set your inflation destination to {knownAccountName} (
+                  {props.inflationDest}).
+                </>
+              )}
+              {props.inflationDest !== LUMENAUT_INFLATION_DESTINATION &&
+                !knownAccountName && (
+                  <>Set your inflation destination to {props.inflationDest}.</>
+                )}
+            </p>
+          )}
+        </Fragment>
+      )}
+
+      {type === TYPE.payment && (
+        <Fragment>
+          <p>
+            <>
+              Send {props.amount} {props.asset.code} to {props.destination}
+            </>
+          </p>
+        </Fragment>
+      )}
+
+      {!TYPE[type] && <pre>{JSON.stringify(props, null, 2)}</pre>}
+    </El>
+  );
+};
+
+OperationViewer.propTypes = {
+  type: PropTypes.string.isRequired,
+
+  // changeTrust
+  line: PropTypes.shape({
+    code: PropTypes.string.isRequired,
+    issuer: PropTypes.string.isRequired,
+  }),
+  limit: PropTypes.string,
+
+  // manageOffer
+  buying: PropTypes.shape({
+    code: PropTypes.string.isRequired,
+    issuer: PropTypes.string,
+  }),
+  selling: PropTypes.shape({
+    code: PropTypes.string.isRequired,
+    issuer: PropTypes.string,
+  }),
+  amount: PropTypes.string,
+  price: PropTypes.string,
+  offerId: PropTypes.string,
+
+  // setOptions
+  inflationDest: PropTypes.string,
+
+  // payment
+  // amount: PropTypes.string, // (already required above)
+  destination: PropTypes.string,
+  asset: PropTypes.shape({
+    code: PropTypes.string.isRequired,
+  }),
+};
+
+export default OperationViewer;

--- a/playground/src/components/Payments.js
+++ b/playground/src/components/Payments.js
@@ -1,6 +1,5 @@
 import React, { Component } from "react";
 import moment from "moment";
-import Json from "react-json-view";
 
 class Payments extends Component {
   state = {

--- a/playground/src/components/TransactionViewer.js
+++ b/playground/src/components/TransactionViewer.js
@@ -1,0 +1,108 @@
+import React from "react";
+import PropTypes from "prop-types";
+import styled from "styled-components";
+
+import OperationViewer from "./OperationViewer";
+
+export function getXDRFromTransaction(transaction) {
+  const xdrBuffer = transaction.toEnvelope().toXDR();
+  return xdrBuffer.toString("base64");
+}
+
+const El = styled.div``;
+
+const PreEl = styled.div`
+  max-height: 300px;
+  overflow: auto;
+`;
+
+const PreHeaderEl = styled.div`
+  padding: 10px 20px;
+`;
+
+const PreSubheaderEl = styled.div`
+  padding: 10px 20px;
+  font-size: 12px;
+  line-height: 20px;
+`;
+
+const PreBodyEl = styled.div`
+  padding: 0 20px;
+`;
+
+const DetailsEl = styled.div`
+  font-size: 12px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+const TransactionViewer = ({ transaction }) => {
+  const { operations, memo } = transaction;
+
+  const xdr = getXDRFromTransaction(transaction);
+
+  const hasMemo = memo && memo._type && memo._value;
+
+  const memoValue =
+    // If it's binary, render as hex. Create a new array because otherwise it's
+    // still a Uint8Array, which doesn't like holding string values.
+    memo._value instanceof Uint8Array
+      ? [...memo._value].map((x) => `0${x.toString(16)}`.substr(-2)).join("")
+      : memo._value;
+
+  return (
+    <El>
+      <PreEl>
+        <PreHeaderEl>
+          <h2>{operations.length} operation(s)</h2>
+        </PreHeaderEl>
+        <PreBodyEl>
+          {operations.map((operation, i) => (
+            // eslint-disable-next-line react/no-array-index-key
+            <OperationViewer {...operation} key={i} />
+          ))}
+        </PreBodyEl>
+        <PreSubheaderEl>
+          {!hasMemo && (
+            <em>
+              <>No memo attached!</>
+            </em>
+          )}
+          {hasMemo && `Memo (${memo._type}): ${memoValue}`}
+        </PreSubheaderEl>
+      </PreEl>
+
+      <DetailsEl>
+        <p>Hash: {transaction.hash().toString("hex")}</p>
+
+        <a
+          href={`https://www.stellar.org/laboratory/#xdr-viewer?type=TransactionEnvelope&input=${encodeURIComponent(
+            xdr,
+          )}`}
+          withIcon
+          withUnderline
+        >
+          <>View in Stellar Laboratory</>
+        </a>
+      </DetailsEl>
+    </El>
+  );
+};
+
+TransactionViewer.propTypes = {
+  transaction: PropTypes.shape({
+    operations: PropTypes.arrayOf(PropTypes.object).isRequired,
+    signatures: PropTypes.arrayOf(PropTypes.object).isRequired,
+    source: PropTypes.string.isRequired,
+    fee: PropTypes.number.isRequired,
+    sequence: PropTypes.string.isRequired,
+    memo: PropTypes.object,
+
+    // functions
+    hash: PropTypes.func,
+    toEnvelope: PropTypes.func,
+  }).isRequired,
+};
+
+export default TransactionViewer;

--- a/playground/yarn.lock
+++ b/playground/yarn.lock
@@ -1481,10 +1481,10 @@
     "@types/react-native" "*"
     csstype "^2.2.0"
 
-"@types/urijs@^1.19.2":
-  version "1.19.3"
-  resolved "https://registry.yarnpkg.com/@types/urijs/-/urijs-1.19.3.tgz#ed90d38baf3eff1627544ad6ed3bcdeb79ef3533"
-  integrity sha512-L5tP2dEIV+OMVEVRhf8PCFMNMyO5ZBodrXpEqnGczky60lcv8l5Kl9Yi4J1yxhSVfHUe+Pr2nXJfDM+rUYNs3w==
+"@types/urijs@^1.19.6":
+  version "1.19.8"
+  resolved "https://registry.yarnpkg.com/@types/urijs/-/urijs-1.19.8.tgz#a66b2fd8b1d3cf3ef5bae7ca093b7d1b50e48c0a"
+  integrity sha512-SVQd2Qq0oL+b8VtJbQyv0cMIdU7fbRDcg2JIpcBvv+GUayJ3c5Ll1K+iivZl6ifcI6NbYcwjqDjljDFSiSGOeA==
 
 "@types/yargs-parser@*":
   version "13.1.0"
@@ -3007,7 +3007,7 @@ core-js@^1.0.0:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
   integrity sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=
 
-core-js@^2.4.0, core-js@^2.6.3:
+core-js@^2.4.0:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.9.tgz#6b4b214620c834152e179323727fc19741b084f2"
   integrity sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==
@@ -6030,12 +6030,11 @@ js-tokens@^3.0.2:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
   integrity sha1-mGbfOVECEw449/mWvOtlRDIJwls=
 
-js-xdr@^1.1.1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/js-xdr/-/js-xdr-1.1.2.tgz#aba1f0952508c83f33dd7e774fa9231b3073992b"
-  integrity sha512-ipiz1CnsyjLsba+QQd5jezGXddNKGa4oO9EODy0kWr3G3R8MNslIxkhQFpyRfY3yoY7YplhRVfC3cmXb4AobZQ==
+js-xdr@^1.1.3:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/js-xdr/-/js-xdr-1.1.4.tgz#678df4c6f8c7960de85bdf3bfa02b89df2730777"
+  integrity sha512-Xhwys9hyDZQDisxCKZi2nDhvGg6fKhsEgAUaJlzjwo32mZ2gZVIQl3+w4Le5SX5dsKDsboFdM2gnu5JALWetTg==
   dependencies:
-    core-js "^2.6.3"
     cursor "^0.1.5"
     lodash "^4.17.5"
     long "^2.2.3"
@@ -9539,30 +9538,30 @@ stealthy-require@^1.1.1:
   resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
   integrity sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=
 
-stellar-base@^1.1.1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/stellar-base/-/stellar-base-1.1.2.tgz#7b08031f4a5cf4e95b8137472f367903a225ac3d"
-  integrity sha512-dBifZ2NPeOVtHl7pCaSCfvOedUGhKs3qIfqc/ajk9vsOFnHma0sBxb268kQhGWEAUS5tUKYei2ur4dQtB3rDSA==
+stellar-base@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/stellar-base/-/stellar-base-3.0.2.tgz#09083c8f2eb68eddb820504d3b19576da0632c31"
+  integrity sha512-ZZji4go8gRT932OTuUSggohWWuRIs11C99ShokoIurmWPwh0NsvkxN2cBxfEfQi/TdiO1/DiteCzz7w233AfXA==
   dependencies:
     base32.js "^0.1.0"
     bignumber.js "^4.0.0"
     crc "^3.5.0"
-    js-xdr "^1.1.1"
+    js-xdr "^1.1.3"
     lodash "^4.17.11"
     sha.js "^2.3.6"
     tweetnacl "^1.0.0"
   optionalDependencies:
     sodium-native "^2.3.0"
 
-stellar-sdk@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/stellar-sdk/-/stellar-sdk-2.3.0.tgz#f1c9005912c7c95d74e15fe1f7bd4f9c09841acd"
-  integrity sha512-iaeV8K98kuqgm1KH8dDitTp6qfpBb0XDZDnAVxCBCW9vs7AOnKadJbIKBtvVhuFXob4uRLvA3hfLJAAEjEzDcw==
+stellar-sdk@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/stellar-sdk/-/stellar-sdk-5.0.0.tgz#c9cfd36ed9871142cc3ec9a9bbcd5efc834ec9c0"
+  integrity sha512-/D4OPnUnIXARkNwhnV9fFTBlDdulf/uAM/Gtb3l6T/0ERq8kiBbnI1GEKzlSNi1hWVAPulzpa9hw5NZWUdz4BQ==
   dependencies:
     "@types/eventsource" "^1.1.2"
     "@types/node" ">= 8"
     "@types/randombytes" "^2.0.0"
-    "@types/urijs" "^1.19.2"
+    "@types/urijs" "^1.19.6"
     axios "^0.19.0"
     bignumber.js "^4.0.0"
     detect-node "^2.0.4"
@@ -9570,7 +9569,7 @@ stellar-sdk@^2.3.0:
     eventsource "^1.0.7"
     lodash "^4.17.11"
     randombytes "^2.1.0"
-    stellar-base "^1.1.1"
+    stellar-base "^3.0.0"
     toml "^2.3.0"
     tslib "^1.10.0"
     urijs "^1.19.1"

--- a/playground/yarn.lock
+++ b/playground/yarn.lock
@@ -9,6 +9,13 @@
   dependencies:
     "@babel/highlight" "^7.0.0"
 
+"@babel/code-frame@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.8.3.tgz#33e25903d7481181534e12ec0a25f16b6fcf419e"
+  integrity sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==
+  dependencies:
+    "@babel/highlight" "^7.8.3"
+
 "@babel/core@7.5.5":
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.5.5.tgz#17b2686ef0d6bc58f963dddd68ab669755582c30"
@@ -59,6 +66,16 @@
     lodash "^4.17.13"
     source-map "^0.5.0"
     trim-right "^1.0.1"
+
+"@babel/generator@^7.9.6":
+  version "7.9.6"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.9.6.tgz#5408c82ac5de98cda0d77d8124e99fa1f2170a43"
+  integrity sha512-+htwWKJbH2bL72HRluF8zumBxzuX0ZZUFl3JLNyoUjM/Ho8wnVpPXM6aUz8cfKDqQ/h7zHqKt4xzJteUosckqQ==
+  dependencies:
+    "@babel/types" "^7.9.6"
+    jsesc "^2.5.1"
+    lodash "^4.17.13"
+    source-map "^0.5.0"
 
 "@babel/helper-annotate-as-pure@^7.0.0":
   version "7.0.0"
@@ -130,12 +147,28 @@
     "@babel/template" "^7.1.0"
     "@babel/types" "^7.0.0"
 
+"@babel/helper-function-name@^7.9.5":
+  version "7.9.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.9.5.tgz#2b53820d35275120e1874a82e5aabe1376920a5c"
+  integrity sha512-JVcQZeXM59Cd1qanDUxv9fgJpt3NeKUaqBqUEvfmQ+BCOKq2xUgaWZW2hr0dkbyJgezYuplEoh5knmrnS68efw==
+  dependencies:
+    "@babel/helper-get-function-arity" "^7.8.3"
+    "@babel/template" "^7.8.3"
+    "@babel/types" "^7.9.5"
+
 "@babel/helper-get-function-arity@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz#83572d4320e2a4657263734113c42868b64e49c3"
   integrity sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==
   dependencies:
     "@babel/types" "^7.0.0"
+
+"@babel/helper-get-function-arity@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz#b894b947bd004381ce63ea1db9f08547e920abd5"
+  integrity sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==
+  dependencies:
+    "@babel/types" "^7.8.3"
 
 "@babel/helper-hoist-variables@^7.4.4":
   version "7.4.4"
@@ -225,6 +258,18 @@
   dependencies:
     "@babel/types" "^7.4.4"
 
+"@babel/helper-split-export-declaration@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz#31a9f30070f91368a7182cf05f831781065fc7a9"
+  integrity sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==
+  dependencies:
+    "@babel/types" "^7.8.3"
+
+"@babel/helper-validator-identifier@^7.9.0", "@babel/helper-validator-identifier@^7.9.5":
+  version "7.9.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz#90977a8e6fbf6b431a7dc31752eee233bf052d80"
+  integrity sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g==
+
 "@babel/helper-wrap-function@^7.1.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-wrap-function/-/helper-wrap-function-7.2.0.tgz#c4e0012445769e2815b55296ead43a958549f6fa"
@@ -253,10 +298,24 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
+"@babel/highlight@^7.8.3":
+  version "7.9.0"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.9.0.tgz#4e9b45ccb82b79607271b2979ad82c7b68163079"
+  integrity sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.9.0"
+    chalk "^2.0.0"
+    js-tokens "^4.0.0"
+
 "@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.4.3", "@babel/parser@^7.5.5", "@babel/parser@^7.6.0":
   version "7.6.0"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.6.0.tgz#3e05d0647432a8326cb28d0de03895ae5a57f39b"
   integrity sha512-+o2q111WEx4srBs7L9eJmcwi655eD8sXniLqMB93TBK9GrNzGrxDWSjiqz2hLU0Ha8MTXFIP0yd9fNdP+m43ZQ==
+
+"@babel/parser@^7.8.6", "@babel/parser@^7.9.6":
+  version "7.9.6"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.9.6.tgz#3b1bbb30dabe600cd72db58720998376ff653bc7"
+  integrity sha512-AoeIEJn8vt+d/6+PXDRPaksYhnlbMIiejioBZvvMQsOjW/JYK6k/0dKnvvP3EhK5GfMBWDPtrxRtegWdAcdq9Q==
 
 "@babel/plugin-proposal-async-generator-functions@^7.2.0":
   version "7.2.0"
@@ -862,6 +921,15 @@
     "@babel/parser" "^7.6.0"
     "@babel/types" "^7.6.0"
 
+"@babel/template@^7.8.3":
+  version "7.8.6"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.8.6.tgz#86b22af15f828dfb086474f964dcc3e39c43ce2b"
+  integrity sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==
+  dependencies:
+    "@babel/code-frame" "^7.8.3"
+    "@babel/parser" "^7.8.6"
+    "@babel/types" "^7.8.6"
+
 "@babel/traverse@^7.0.0", "@babel/traverse@^7.1.0", "@babel/traverse@^7.4.3", "@babel/traverse@^7.4.4", "@babel/traverse@^7.5.5", "@babel/traverse@^7.6.0":
   version "7.6.0"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.6.0.tgz#389391d510f79be7ce2ddd6717be66d3fed4b516"
@@ -877,12 +945,36 @@
     globals "^11.1.0"
     lodash "^4.17.13"
 
+"@babel/traverse@^7.4.5":
+  version "7.9.6"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.9.6.tgz#5540d7577697bf619cc57b92aa0f1c231a94f442"
+  integrity sha512-b3rAHSjbxy6VEAvlxM8OV/0X4XrG72zoxme6q1MOoe2vd0bEc+TwayhuC1+Dfgqh1QEG+pj7atQqvUprHIccsg==
+  dependencies:
+    "@babel/code-frame" "^7.8.3"
+    "@babel/generator" "^7.9.6"
+    "@babel/helper-function-name" "^7.9.5"
+    "@babel/helper-split-export-declaration" "^7.8.3"
+    "@babel/parser" "^7.9.6"
+    "@babel/types" "^7.9.6"
+    debug "^4.1.0"
+    globals "^11.1.0"
+    lodash "^4.17.13"
+
 "@babel/types@^7.0.0", "@babel/types@^7.2.0", "@babel/types@^7.3.0", "@babel/types@^7.4.0", "@babel/types@^7.4.4", "@babel/types@^7.5.5", "@babel/types@^7.6.0":
   version "7.6.1"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.6.1.tgz#53abf3308add3ac2a2884d539151c57c4b3ac648"
   integrity sha512-X7gdiuaCmA0uRjCmRtYJNAVCc/q+5xSgsfKJHqMN4iNLILX39677fJE1O40arPMh0TTtS9ItH67yre6c7k6t0g==
   dependencies:
     esutils "^2.0.2"
+    lodash "^4.17.13"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.8.3", "@babel/types@^7.8.6", "@babel/types@^7.9.5", "@babel/types@^7.9.6":
+  version "7.9.6"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.9.6.tgz#2c5502b427251e9de1bd2dff95add646d95cc9f7"
+  integrity sha512-qxXzvBO//jO9ZnoasKF1uJzHd2+M6Q2ZPIVfnFps8JJvXy0ZBbwbNOmE6SGIY5XOY6d1Bo5lb9d9RJ8nv3WSeA==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.9.5"
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
@@ -911,15 +1003,37 @@
   dependencies:
     "@emotion/memoize" "0.7.3"
 
+"@emotion/is-prop-valid@^0.8.8":
+  version "0.8.8"
+  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz#db28b1c4368a259b60a97311d6a952d4fd01ac1a"
+  integrity sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==
+  dependencies:
+    "@emotion/memoize" "0.7.4"
+
 "@emotion/memoize@0.7.3":
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.3.tgz#5b6b1c11d6a6dddf1f2fc996f74cf3b219644d78"
   integrity sha512-2Md9mH6mvo+ygq1trTeVp2uzAKwE2P7In0cRpD/M9Q70aH8L+rxMLbb3JCN2JoSWsV2O+DdFjfbbXoMoLBczow==
 
+"@emotion/memoize@0.7.4":
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.4.tgz#19bf0f5af19149111c40d98bb0cf82119f5d9eeb"
+  integrity sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==
+
+"@emotion/stylis@^0.8.4":
+  version "0.8.5"
+  resolved "https://registry.yarnpkg.com/@emotion/stylis/-/stylis-0.8.5.tgz#deacb389bd6ee77d1e7fcaccce9e16c5c7e78e04"
+  integrity sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ==
+
 "@emotion/unitless@^0.7.0":
   version "0.7.4"
   resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.4.tgz#a87b4b04e5ae14a88d48ebef15015f6b7d1f5677"
   integrity sha512-kBa+cDHOR9jpRJ+kcGMsysrls0leukrm68DmFQoMIWQcXdr2cZvyvypWuGYT7U+9kAExUE7+T7r6G3C3A6L8MQ==
+
+"@emotion/unitless@^0.7.4":
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.5.tgz#77211291c1900a700b8a78cfafda3160d76949ed"
+  integrity sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==
 
 "@hapi/address@2.x.x":
   version "2.1.1"
@@ -3070,6 +3184,15 @@ css-to-react-native@^2.2.2:
     css-color-keywords "^1.0.0"
     postcss-value-parser "^3.3.0"
 
+css-to-react-native@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/css-to-react-native/-/css-to-react-native-3.0.0.tgz#62dbe678072a824a689bcfee011fc96e02a7d756"
+  integrity sha512-Ro1yETZA813eoyUp2GDBhG2j+YggidUmzO1/v9eYBKR2EHVEniE2MI/NqpTQ954BMpTPZFsGNPm46qFB9dpaPQ==
+  dependencies:
+    camelize "^1.0.0"
+    css-color-keywords "^1.0.0"
+    postcss-value-parser "^4.0.2"
+
 css-tree@1.0.0-alpha.29:
   version "1.0.0-alpha.29"
   resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-1.0.0-alpha.29.tgz#3fa9d4ef3142cbd1c301e7664c1f352bd82f5a39"
@@ -4766,6 +4889,13 @@ hmac-drbg@^1.0.0:
     hash.js "^1.0.3"
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
+
+hoist-non-react-statics@^3.0.0:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
+  integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
+  dependencies:
+    react-is "^16.7.0"
 
 hoist-non-react-statics@^3.1.0:
   version "3.3.0"
@@ -8062,6 +8192,11 @@ postcss-value-parser@^4.0.0:
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.0.2.tgz#482282c09a42706d1fc9a069b73f44ec08391dc9"
   integrity sha512-LmeoohTpp/K4UiyQCwuGWlONxXamGzCMtFxLq4W1nZVGIQLYvMCJx3yAF9qyyuFpflABI9yVdtJAqbihOsCsJQ==
 
+postcss-value-parser@^4.0.2:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz#443f6a20ced6481a2bda4fa8532a6e55d789a2cb"
+  integrity sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==
+
 postcss-values-parser@^2.0.0, postcss-values-parser@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/postcss-values-parser/-/postcss-values-parser-2.0.1.tgz#da8b472d901da1e205b47bdc98637b9e9e550e5f"
@@ -9127,6 +9262,11 @@ shallow-clone@^3.0.0:
   dependencies:
     kind-of "^6.0.2"
 
+shallowequal@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.1.0.tgz#188d521de95b9087404fd4dcb68b13df0ae4e7f8"
+  integrity sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==
+
 shebang-command@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
@@ -9615,6 +9755,22 @@ styled-components@^4.2.0:
     react-is "^16.6.0"
     stylis "^3.5.0"
     stylis-rule-sheet "^0.0.10"
+    supports-color "^5.5.0"
+
+styled-components@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-5.1.0.tgz#2e3985b54f461027e1c91af3229e1c2530872a4e"
+  integrity sha512-0Qs2wEkFBXHFlysz6CV831VG6HedcrFUwChjnWylNivsx14MtmqQsohi21rMHZxzuTba063dEyoe/SR6VGJI7Q==
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@babel/traverse" "^7.4.5"
+    "@emotion/is-prop-valid" "^0.8.8"
+    "@emotion/stylis" "^0.8.4"
+    "@emotion/unitless" "^0.7.4"
+    babel-plugin-styled-components ">= 1"
+    css-to-react-native "^3.0.0"
+    hoist-non-react-statics "^3.0.0"
+    shallowequal "^1.1.0"
     supports-color "^5.5.0"
 
 stylehacks@^4.0.0:

--- a/src/KeyManager.test.ts
+++ b/src/KeyManager.test.ts
@@ -207,7 +207,7 @@ describe("KeyManager", function() {
     );
 
     const transaction = new StellarBase.TransactionBuilder(source, {
-      fee: 100,
+      fee: "100",
       networkPassphrase: network,
     })
       .addOperation(StellarBase.Operation.inflation({}))

--- a/src/data/DataProvider.test.ts
+++ b/src/data/DataProvider.test.ts
@@ -1,3 +1,4 @@
+import { Networks } from "stellar-sdk";
 import { generatePlaintextKey } from "../fixtures/keys";
 import { DataProvider } from "./DataProvider";
 
@@ -8,6 +9,7 @@ describe("Account validation", () => {
         // @ts-ignore
         accountOrKey: null,
         serverUrl: "https://horizon.stellar.org",
+        networkPassphrase: Networks.PUBLIC,
       });
       expect(provider).not.toBeInstanceOf(DataProvider);
     } catch (e) {
@@ -22,6 +24,7 @@ describe("Account validation", () => {
         accountOrKey:
           "GDZBHQFIHLVDF6GCRV5DT2STB6ZXAJR3JFGZNXNPLB35TH5GNMUVIAQP",
         serverUrl: "https://horizon.stellar.org",
+        networkPassphrase: Networks.PUBLIC,
       });
       expect(provider).toBeInstanceOf(DataProvider);
     } catch (e) {
@@ -34,6 +37,7 @@ describe("Account validation", () => {
       const provider = new DataProvider({
         accountOrKey: generatePlaintextKey(),
         serverUrl: "https://horizon.stellar.org",
+        networkPassphrase: Networks.PUBLIC,
       });
       expect(provider).toBeInstanceOf(DataProvider);
     } catch (e) {
@@ -47,6 +51,7 @@ describe("Account validation", () => {
       provider = new DataProvider({
         accountOrKey: "I am not a stupid key you dumbdumb",
         serverUrl: "https://horizon.stellar.org",
+        networkPassphrase: Networks.PUBLIC,
       });
     } catch (e) {
       expect(e).toBeTruthy();

--- a/src/data/DataProvider.ts
+++ b/src/data/DataProvider.ts
@@ -1,5 +1,14 @@
 import debounce from "lodash/debounce";
-import { Keypair, Server, ServerApi, StrKey } from "stellar-sdk";
+import {
+  Account as StellarAccount,
+  Asset,
+  Keypair,
+  Operation,
+  Server,
+  ServerApi,
+  StrKey,
+  TransactionBuilder,
+} from "stellar-sdk";
 
 import {
   Account,
@@ -13,6 +22,8 @@ import {
   WatcherParams,
 } from "../types";
 
+import { getStellarSdkAsset } from "./index";
+
 import { makeDisplayableBalances } from "./makeDisplayableBalances";
 import { makeDisplayableOffers } from "./makeDisplayableOffers";
 import { makeDisplayablePayments } from "./makeDisplayablePayments";
@@ -21,6 +32,7 @@ import { makeDisplayableTrades } from "./makeDisplayableTrades";
 export interface DataProviderParams {
   serverUrl: string;
   accountOrKey: Account | string;
+  networkPassphrase: string;
 }
 
 function isAccount(obj: any): obj is Account {
@@ -45,6 +57,7 @@ export class DataProvider {
   private accountKey: string;
   private serverUrl: string;
   private server: Server;
+  private networkPassphrase: string;
   private _watcherTimeouts: WatcherTimeoutsObject;
 
   private effectStreamEnder?: () => void;
@@ -64,6 +77,10 @@ export class DataProvider {
       throw new Error("No server url provided.");
     }
 
+    if (!params.networkPassphrase) {
+      throw new Error("No network passphrase provided.");
+    }
+
     // make sure the account key is a real account
     try {
       Keypair.fromPublicKey(accountKey);
@@ -73,6 +90,7 @@ export class DataProvider {
 
     this.callbacks = {};
     this.errorHandlers = {};
+    this.networkPassphrase = params.networkPassphrase;
     this.serverUrl = params.serverUrl;
     this.server = new Server(this.serverUrl);
     this.accountKey = accountKey;
@@ -122,7 +140,8 @@ export class DataProvider {
   ): Promise<Collection<Offer>> {
     // first, fetch all offers
     const offers = await this.server
-      .offers("accounts", this.accountKey)
+      .offers()
+      .forAccount(this.accountKey)
       .limit(params.limit || 10)
       .order(params.order || "desc")
       .cursor(params.cursor || "")
@@ -185,6 +204,7 @@ export class DataProvider {
         thresholds: accountSummary.thresholds,
         signers: accountSummary.signers,
         flags: accountSummary.flags,
+        sequenceNumber: accountSummary.sequence,
         balances,
       };
     } catch (err) {
@@ -312,6 +332,7 @@ export class DataProvider {
    */
   public async getStripAndMergeAccountTransaction(destinationKey: string) {
     // throw if the destination is invalid
+    console.log("!!!!!!!!!!!!!! check out this dest: ", destinationKey);
     if (!StrKey.isValidEd25519PublicKey(destinationKey)) {
       throw new Error("The destination is not a valid Stellar address.");
     }
@@ -348,13 +369,13 @@ export class DataProvider {
     let offers: ServerApi.OfferRecord[] = [];
     try {
       let additionalOffers: ServerApi.OfferRecord[] | undefined;
-      let cursor: string | undefined;
       let next: () => Promise<Collection<ServerApi.OfferRecord>> = () =>
         this.server
-          .offers("accounts", this.accountKey)
+          .offers()
+          .forAccount(this.accountKey)
           .limit(25)
           .order("desc")
-          .cursor(cursor || "")
+          .cursor("")
           .call();
 
       while (additionalOffers === undefined || additionalOffers.length) {
@@ -362,13 +383,88 @@ export class DataProvider {
         additionalOffers = res.records;
         next = res.next;
         offers = [...offers, ...additionalOffers];
-        console.log("Open offers list: ", openOffers);
+        console.log("Open offers list: ", offers);
       }
     } catch (e) {
       throw new Error(`Couldn't fetch open offers, error: ${e.toString()}`);
     }
 
-    let operations;
+    const accountObject = new StellarAccount(
+      this.accountKey,
+      account.sequenceNumber,
+    );
+
+    let fee = "1000";
+
+    try {
+      const feeStats = await this.server.feeStats();
+      fee = feeStats.max_fee.p70;
+    } catch (e) {
+      // do nothing
+    }
+
+    const transaction = new TransactionBuilder(accountObject, {
+      fee,
+      networkPassphrase: this.networkPassphrase,
+      timebounds: await this.server.fetchTimebounds(10 * 60 * 1000),
+    });
+
+    // strip offers
+    offers.forEach((offer) => {
+      const { seller, selling, buying, id } = offer;
+
+      let operation;
+
+      // check if we're the seller
+      if (seller === this.accountKey) {
+        operation = Operation.manageSellOffer({
+          selling:
+            selling.asset_code && selling.asset_issuer
+              ? new Asset(selling.asset_code, selling.asset_issuer)
+              : Asset.native(),
+          buying:
+            buying.asset_code && buying.asset_issuer
+              ? new Asset(buying.asset_code, buying.asset_issuer)
+              : Asset.native(),
+          amount: "0",
+          price: "0",
+          offerId: id,
+        });
+      } else {
+        operation = Operation.manageBuyOffer({
+          selling:
+            selling.asset_code && selling.asset_issuer
+              ? new Asset(selling.asset_code, selling.asset_issuer)
+              : Asset.native(),
+          buying:
+            buying.asset_code && buying.asset_issuer
+              ? new Asset(buying.asset_code, buying.asset_issuer)
+              : Asset.native(),
+          buyAmount: "0",
+          price: "0",
+          offerId: id,
+        });
+      }
+      transaction.addOperation(operation);
+    });
+
+    // strip trustlines
+    Object.keys(account.balances).forEach((identifier) => {
+      if (identifier === "native") {
+        return;
+      }
+
+      const balance = account.balances[identifier];
+
+      transaction.addOperation(
+        Operation.changeTrust({
+          asset: getStellarSdkAsset(balance.token),
+          limit: "0",
+        }),
+      );
+    });
+
+    return transaction.build();
   }
 
   private async _processOpenOffers(
@@ -377,10 +473,10 @@ export class DataProvider {
     // find all offerids and check for trades of each
     const tradeRequests: Array<
       Promise<ServerApi.CollectionPage<ServerApi.TradeRecord>>
-    > = offers.records.map(({ id }: { id: string }) =>
+    > = offers.records.map(({ id }: { id: number | string }) =>
       this.server
         .trades()
-        .forOffer(id)
+        .forOffer(`${id}`)
         .call(),
     );
 

--- a/src/data/DataProvider.ts
+++ b/src/data/DataProvider.ts
@@ -332,7 +332,6 @@ export class DataProvider {
    */
   public async getStripAndMergeAccountTransaction(destinationKey: string) {
     // throw if the destination is invalid
-    console.log("!!!!!!!!!!!!!! check out this dest: ", destinationKey);
     if (!StrKey.isValidEd25519PublicKey(destinationKey)) {
       throw new Error("The destination is not a valid Stellar address.");
     }
@@ -375,7 +374,6 @@ export class DataProvider {
           .forAccount(this.accountKey)
           .limit(25)
           .order("desc")
-          .cursor("")
           .call();
 
       while (additionalOffers === undefined || additionalOffers.length) {
@@ -383,10 +381,9 @@ export class DataProvider {
         additionalOffers = res.records;
         next = res.next;
         offers = [...offers, ...additionalOffers];
-        console.log("Open offers list: ", offers);
       }
     } catch (e) {
-      throw new Error(`Couldn't fetch open offers, error: ${e.toString()}`);
+      throw new Error(`Couldn't fetch open offers, error: ${e.stack}`);
     }
 
     const accountObject = new StellarAccount(

--- a/src/data/DataProvider.ts
+++ b/src/data/DataProvider.ts
@@ -461,6 +461,12 @@ export class DataProvider {
       );
     });
 
+    transaction.addOperation(
+      Operation.accountMerge({
+        destination: destinationKey,
+      }),
+    );
+
     return transaction.build();
   }
 

--- a/src/data/makeDisplayableOffers.test.ts
+++ b/src/data/makeDisplayableOffers.test.ts
@@ -20,7 +20,7 @@ it("makes offers from partial fill", () => {
   );
 
   expect(offers[0]).toEqual({
-    id: 76884793,
+    id: "76884793",
     offerer: {
       publicKey: "PHYREXIA",
     },

--- a/src/data/makeDisplayableOffers.ts
+++ b/src/data/makeDisplayableOffers.ts
@@ -82,7 +82,7 @@ export function makeDisplayableOffers(
       }, new BigNumber(0));
 
       return {
-        id,
+        id: `${id}`,
         offerer: {
           publicKey: seller as string,
         },

--- a/src/types/data.ts
+++ b/src/types/data.ts
@@ -165,6 +165,7 @@ export interface AccountDetails {
   signers: ServerApi.AccountRecordSigners[];
   flags: Horizon.Flags;
   balances: BalanceMap;
+  sequenceNumber: string;
 }
 
 export interface CollectionParams {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1085,13 +1085,6 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
 
-"@types/stellar-base@^0.10.2":
-  version "0.10.2"
-  resolved "https://registry.yarnpkg.com/@types/stellar-base/-/stellar-base-0.10.2.tgz#8a6bbaabde140971ccab4cf202151de84740fa29"
-  integrity sha512-MOilZXnnLqxCa3f2Xr7phqI8mbfz5j1BhWs6XrGwHfNTL9XQPOyLBN9tBWIsDIRZ1VyUZQ2YQLTjSppsB8/iUQ==
-  dependencies:
-    "@types/node" "*"
-
 "@types/urijs@^1.19.6":
   version "1.19.8"
   resolved "https://registry.yarnpkg.com/@types/urijs/-/urijs-1.19.8.tgz#a66b2fd8b1d3cf3ef5bae7ca093b7d1b50e48c0a"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1092,10 +1092,10 @@
   dependencies:
     "@types/node" "*"
 
-"@types/urijs@^1.19.2":
-  version "1.19.3"
-  resolved "https://registry.yarnpkg.com/@types/urijs/-/urijs-1.19.3.tgz#ed90d38baf3eff1627544ad6ed3bcdeb79ef3533"
-  integrity sha512-L5tP2dEIV+OMVEVRhf8PCFMNMyO5ZBodrXpEqnGczky60lcv8l5Kl9Yi4J1yxhSVfHUe+Pr2nXJfDM+rUYNs3w==
+"@types/urijs@^1.19.6":
+  version "1.19.8"
+  resolved "https://registry.yarnpkg.com/@types/urijs/-/urijs-1.19.8.tgz#a66b2fd8b1d3cf3ef5bae7ca093b7d1b50e48c0a"
+  integrity sha512-SVQd2Qq0oL+b8VtJbQyv0cMIdU7fbRDcg2JIpcBvv+GUayJ3c5Ll1K+iivZl6ifcI6NbYcwjqDjljDFSiSGOeA==
 
 "@types/yargs@^12.0.2":
   version "12.0.12"
@@ -2227,11 +2227,6 @@ core-js@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.0.0.tgz#a8dbfa978d29bfc263bfb66c556d0ca924c28957"
   integrity sha512-WBmxlgH2122EzEJ6GH8o9L/FeoUKxxxZ6q6VUxoTlsE4EvbTWKJb447eyVxTEuq0LpXjlq/kCB2qgBvsYRkLvQ==
-
-core-js@^2.6.3:
-  version "2.6.9"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.9.tgz#6b4b214620c834152e179323727fc19741b084f2"
-  integrity sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -4290,12 +4285,11 @@ js-levenshtein@^1.1.3:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-xdr@^1.1.1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/js-xdr/-/js-xdr-1.1.2.tgz#aba1f0952508c83f33dd7e774fa9231b3073992b"
-  integrity sha512-ipiz1CnsyjLsba+QQd5jezGXddNKGa4oO9EODy0kWr3G3R8MNslIxkhQFpyRfY3yoY7YplhRVfC3cmXb4AobZQ==
+js-xdr@^1.1.3:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/js-xdr/-/js-xdr-1.1.4.tgz#678df4c6f8c7960de85bdf3bfa02b89df2730777"
+  integrity sha512-Xhwys9hyDZQDisxCKZi2nDhvGg6fKhsEgAUaJlzjwo32mZ2gZVIQl3+w4Le5SX5dsKDsboFdM2gnu5JALWetTg==
   dependencies:
-    core-js "^2.6.3"
     cursor "^0.1.5"
     lodash "^4.17.5"
     long "^2.2.3"
@@ -6550,30 +6544,30 @@ stealthy-require@^1.1.1:
   resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
   integrity sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=
 
-stellar-base@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/stellar-base/-/stellar-base-2.1.2.tgz#bd7cc27f494fb1c7d7f2563efe25f7572880b1bf"
-  integrity sha512-/U0QFfMwCAa9I0TukfLzUhHvbEXSH2gGSB5ZbabeisnVf1FFFQBjazsNBfbKADrExWE+H3833DpckE6jynlIqg==
+stellar-base@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/stellar-base/-/stellar-base-3.0.2.tgz#09083c8f2eb68eddb820504d3b19576da0632c31"
+  integrity sha512-ZZji4go8gRT932OTuUSggohWWuRIs11C99ShokoIurmWPwh0NsvkxN2cBxfEfQi/TdiO1/DiteCzz7w233AfXA==
   dependencies:
     base32.js "^0.1.0"
     bignumber.js "^4.0.0"
     crc "^3.5.0"
-    js-xdr "^1.1.1"
+    js-xdr "^1.1.3"
     lodash "^4.17.11"
     sha.js "^2.3.6"
     tweetnacl "^1.0.0"
   optionalDependencies:
     sodium-native "^2.3.0"
 
-stellar-sdk@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/stellar-sdk/-/stellar-sdk-3.2.0.tgz#3dd707727adb012dccd6863fd4eb8a6ff9e5e9d8"
-  integrity sha512-6Ovd9SN3eHbW9eEfjiTDH5agZAjW/xuC89645Eoppo7YlmA5Uf6ObI4XdrO0ifvsWxswCQ5syF4gbI1f04spQg==
+stellar-sdk@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/stellar-sdk/-/stellar-sdk-5.0.0.tgz#c9cfd36ed9871142cc3ec9a9bbcd5efc834ec9c0"
+  integrity sha512-/D4OPnUnIXARkNwhnV9fFTBlDdulf/uAM/Gtb3l6T/0ERq8kiBbnI1GEKzlSNi1hWVAPulzpa9hw5NZWUdz4BQ==
   dependencies:
     "@types/eventsource" "^1.1.2"
     "@types/node" ">= 8"
     "@types/randombytes" "^2.0.0"
-    "@types/urijs" "^1.19.2"
+    "@types/urijs" "^1.19.6"
     axios "^0.19.0"
     bignumber.js "^4.0.0"
     detect-node "^2.0.4"
@@ -6581,7 +6575,7 @@ stellar-sdk@^3.2.0:
     eventsource "^1.0.7"
     lodash "^4.17.11"
     randombytes "^2.1.0"
-    stellar-base "^2.1.2"
+    stellar-base "^3.0.0"
     toml "^2.3.0"
     tslib "^1.10.0"
     urijs "^1.19.1"


### PR DESCRIPTION
Add `DataProvider#getStripAndMergeAccountTransaction`, a
function that makes it easier to merge accounts with no balances but
trustlines, outstanding offers, etc. Returns a transaction to strip and merge
the account into another.

Right now, the function requires an account with zeroed non-native balances. 
In the future, it could auto-path-payment all the users funds.

Other changes:

- Upgraded `stellar-sdk` to 5.0.0.
- [DataProvider] Constructor now requires a `networkPassphrase` param.
