### PR TITLE
description change from public key to key id

### DIFF
--- a/src/KeyManager.ts
+++ b/src/KeyManager.ts
@@ -206,7 +206,7 @@ export class KeyManager {
   }
 
   /**
-   *  Remove the key specified by this publicKey.
+   *  Remove the key specified by this key id.
    *
    * @async
    * @param id Specifies which key to remove.
@@ -220,7 +220,7 @@ export class KeyManager {
   }
 
   /**
-   * Sign a transaction using the specified publicKey. Supports both using a
+   * Sign a transaction using the specified key id. Supports both using a
    * cached key and going out to the keystore to read and decrypt
    *
    * @async


### PR DESCRIPTION
**WHY?**
Small description change, but I found it confusing with the description using "publicKey" when the key id is what should be getting passed into these functions.

"key id" was the most intuitive description I could think of, but if there's a more descriptive one I can change it