### PR TITLE
SEP-10: Check challenge tokens for signatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - [KeyManager] Added Trezor wallet.
 - [KeyManager] Only sign SEP-10 auth transactions with seq number 0.
+- [KeyManager] Require the auth server's key when fetching SEP-10 tokens, and
+  check the challenge transaction is from that key and signed by it.
 - [DataProvider] Fix `watchPayments` stopper.
 - [KeyManager] Added Lyra wallet.
 

--- a/config/polyfills.js
+++ b/config/polyfills.js
@@ -1,2 +1,2 @@
 global.regeneratorRuntime = require("regenerator-runtime");
-global.fetch = require("jest-fetch-mock");
+require("jest-fetch-mock").enableMocks();

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "concurrently": "^4.1.1",
     "husky": "^1.3.1",
     "jest": "^24.7.1",
-    "jest-fetch-mock": "^2.1.2",
+    "jest-fetch-mock": "^3.0.3",
     "jest-mock-random": "^1.0.3",
     "lint-staged": "^8.1.5",
     "node-localstorage": "^2.1.5",

--- a/src/KeyManager.test.ts
+++ b/src/KeyManager.test.ts
@@ -289,7 +289,7 @@ describe("KeyManager", function() {
           id: keyMetadata.id,
           password,
           authServer,
-          authServerKey: keypair.publicKey(),
+          authServerKey: "no key needed",
         });
 
         expect("This test failed").toBe(null);

--- a/src/KeyManager.test.ts
+++ b/src/KeyManager.test.ts
@@ -507,6 +507,8 @@ describe("KeyManager", function() {
 
       const account = new StellarBase.Account(accountKey.publicKey(), "-1");
 
+      const badKey = StellarBase.Keypair.random();
+
       const txBuilder = new StellarBase.TransactionBuilder(account, {
         fee: "10000",
         networkPassphrase: keyNetwork,
@@ -514,7 +516,7 @@ describe("KeyManager", function() {
         .setTimeout(1000)
         .build();
 
-      txBuilder.sign(StellarBase.Keypair.random());
+      txBuilder.sign(badKey);
 
       const tx = txBuilder.toXDR();
 

--- a/src/KeyManager.test.ts
+++ b/src/KeyManager.test.ts
@@ -289,6 +289,7 @@ describe("KeyManager", function() {
           id: keyMetadata.id,
           password,
           authServer,
+          authServerKey: keypair.publicKey(),
         });
 
         expect("This test failed").toBe(null);
@@ -304,18 +305,18 @@ describe("KeyManager", function() {
       const keyNetwork = StellarBase.Networks.TESTNET;
 
       const token = "👍";
-      const account = new StellarBase.Account(
-        StellarBase.Keypair.random().publicKey(),
-        "-1",
-      );
+      const accountKey = StellarBase.Keypair.random();
+      const account = new StellarBase.Account(accountKey.publicKey(), "-1");
 
-      const tx = new StellarBase.TransactionBuilder(account, {
+      const txBuild = new StellarBase.TransactionBuilder(account, {
         fee: "10000",
         networkPassphrase: keyNetwork,
       })
         .setTimeout(1000)
-        .build()
-        .toXDR();
+        .build();
+      txBuild.sign(accountKey);
+
+      const tx = txBuild.toXDR();
 
       fetch
         // @ts-ignore
@@ -361,6 +362,7 @@ describe("KeyManager", function() {
           id: keyMetadata.id,
           password,
           authServer,
+          authServerKey: account.accountId(),
         });
 
         expect(res).toBe(token);
@@ -423,6 +425,7 @@ describe("KeyManager", function() {
           id: keyMetadata.id,
           password,
           authServer,
+          authServerKey: account.accountId(),
         });
 
         expect("This test failed: transaction didn't cause error").toBe(null);
@@ -493,7 +496,7 @@ describe("KeyManager", function() {
         id: keyMetadata.id,
         password,
         authServer,
-        authServerSigningKey: accountKey.publicKey(),
+        authServerKey: accountKey.publicKey(),
       });
     });
 
@@ -555,7 +558,7 @@ describe("KeyManager", function() {
           id: keyMetadata.id,
           password,
           authServer,
-          authServerSigningKey: accountKey.publicKey(),
+          authServerKey: accountKey.publicKey(),
         });
 
         expect("This test failed: transaction didn't cause error").toBe(null);
@@ -622,7 +625,7 @@ describe("KeyManager", function() {
           id: keyMetadata.id,
           password,
           authServer,
-          authServerSigningKey: realKey,
+          authServerKey: realKey,
         });
 
         expect("This test failed: transaction didn't cause error").toBe(null);

--- a/src/KeyManager.ts
+++ b/src/KeyManager.ts
@@ -275,16 +275,16 @@ export class KeyManager {
    *                           computed as `sha1(private key + public key)`.
    * @param {string} params.password The password that will decrypt that secret
    * @param {string} params.authServer The URL of the authentication server
+   * @param {string} params.authServerKey Check the challenge transaction
+   *                                for this key as source and signature.
    * @param {string} [params.account] The authenticating public key. If not
    *                                provided, then the signers's public key will
    *                                be used instead.
-   * @param {string} [params.authServerSigningKey] If provided, ensure the
-   *                                challenge transaction is signed by this key
    * @returns {Promise<string>} authToken JWT
    */
   // tslint:enable max-line-length
   public async fetchAuthToken(params: GetAuthTokenParams): Promise<AuthToken> {
-    const { id, password, authServer, authServerSigningKey } = params;
+    const { id, password, authServer, authServerKey } = params;
     let { account } = params;
 
     // throw errors for missing params
@@ -374,10 +374,10 @@ export class KeyManager {
       );
     }
 
-    if (authServerSigningKey) {
-      if (firstTransaction.source !== authServerSigningKey) {
+    if (authServerKey) {
+      if (firstTransaction.source !== authServerKey) {
         throw new Error(
-          `Signing key doesn't match: Expected ${authServerSigningKey} but got
+          `Signing key doesn't match: Expected ${authServerKey} but got
           ${firstTransaction.source}`,
         );
       }
@@ -387,14 +387,12 @@ export class KeyManager {
           signature
             .hint()
             .equals(
-              StellarSdk.Keypair.fromPublicKey(
-                authServerSigningKey,
-              ).signatureHint(),
+              StellarSdk.Keypair.fromPublicKey(authServerKey).signatureHint(),
             ),
         )
       ) {
         throw new Error(
-          `Signing key doesn't match: Expected ${authServerSigningKey} but got
+          `Signing key doesn't match: Expected ${authServerKey} but got
           something different`,
         );
       }

--- a/src/KeyManager.ts
+++ b/src/KeyManager.ts
@@ -395,9 +395,7 @@ export class KeyManager {
       ) {
         throw new Error(
           `Signing key doesn't match: Expected ${authServerSigningKey} but got
-          ${firstTransaction.signatures
-            .map((signature) => signature.signature.toString())
-            .join(", ")}`,
+          something different`,
         );
       }
     }

--- a/src/types/keys.ts
+++ b/src/types/keys.ts
@@ -166,5 +166,6 @@ export interface GetAuthTokenParams {
   id: string;
   password: string;
   authServer: string;
+  authServerSigningKey?: string;
   account?: string;
 }

--- a/src/types/keys.ts
+++ b/src/types/keys.ts
@@ -166,6 +166,6 @@ export interface GetAuthTokenParams {
   id: string;
   password: string;
   authServer: string;
-  authServerSigningKey?: string;
+  authServerKey: string;
   account?: string;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2281,13 +2281,12 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-cross-fetch@^2.2.2:
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-2.2.3.tgz#e8a0b3c54598136e037f8650f8e823ccdfac198e"
-  integrity sha512-PrWWNH3yL2NYIb/7WF/5vFG3DCQiXDOVf8k3ijatbrtnwNuhMWLC7YF7uqf53tbTFDzHIUD8oITw4Bxt8ST3Nw==
+cross-fetch@^3.0.4:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.0.5.tgz#2739d2981892e7ab488a7ad03b92df2816e03f4c"
+  integrity sha512-FFLcLtraisj5eteosnX1gf01qYDCOc4fDy0+euOt8Kn9YBY2NtXL/pCoYPavw24NIQkQqm5ZOLsGD5Zzj0gyew==
   dependencies:
-    node-fetch "2.1.2"
-    whatwg-fetch "2.0.4"
+    node-fetch "2.6.0"
 
 cross-spawn@6.0.5, cross-spawn@^6.0.0:
   version "6.0.5"
@@ -3998,13 +3997,13 @@ jest-environment-node@^24.7.1:
     jest-mock "^24.7.0"
     jest-util "^24.7.1"
 
-jest-fetch-mock@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/jest-fetch-mock/-/jest-fetch-mock-2.1.2.tgz#1260b347918e3931c4ec743ceaf60433da661bd0"
-  integrity sha512-tcSR4Lh2bWLe1+0w/IwvNxeDocMI/6yIA2bijZ0fyWxC4kQ18lckQ1n7Yd40NKuisGmcGBRFPandRXrW/ti/Bw==
+jest-fetch-mock@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/jest-fetch-mock/-/jest-fetch-mock-3.0.3.tgz#31749c456ae27b8919d69824f1c2bd85fe0a1f3b"
+  integrity sha512-Ux1nWprtLrdrH4XwE7O7InRY6psIi3GOsqNESJgMJ+M5cv4A8Lh7SN9d2V2kKRZ8ebAfcd1LNyZguAOb6JiDqw==
   dependencies:
-    cross-fetch "^2.2.2"
-    promise-polyfill "^7.1.1"
+    cross-fetch "^3.0.4"
+    promise-polyfill "^8.1.3"
 
 jest-get-type@^24.3.0:
   version "24.3.0"
@@ -5023,10 +5022,10 @@ node-cleanup@^2.1.2:
   resolved "https://registry.yarnpkg.com/node-cleanup/-/node-cleanup-2.1.2.tgz#7ac19abd297e09a7f72a71545d951b517e4dde2c"
   integrity sha1-esGavSl+Caf3KnFUXZUbUX5N3iw=
 
-node-fetch@2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.1.2.tgz#ab884e8e7e57e38a944753cec706f788d1768bb5"
-  integrity sha1-q4hOjn5X44qUR1POxwb3iNF2i7U=
+node-fetch@2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
+  integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
 
 node-gyp-build@^4.1.0:
   version "4.1.0"
@@ -5666,10 +5665,10 @@ promise-inflight@^1.0.1:
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
   integrity sha1-mEcocL8igTL8vdhoEputEsPAKeM=
 
-promise-polyfill@^7.1.1:
-  version "7.1.2"
-  resolved "https://registry.yarnpkg.com/promise-polyfill/-/promise-polyfill-7.1.2.tgz#ab05301d8c28536301622d69227632269a70ca3b"
-  integrity sha512-FuEc12/eKqqoRYIGBrUptCBRhobL19PS2U31vMNTfyck1FxPyMfgsXyW4Mav85y/ZN1hop3hOwRlUDok23oYfQ==
+promise-polyfill@^8.1.3:
+  version "8.1.3"
+  resolved "https://registry.yarnpkg.com/promise-polyfill/-/promise-polyfill-8.1.3.tgz#8c99b3cf53f3a91c68226ffde7bde81d7f904116"
+  integrity sha512-MG5r82wBzh7pSKDRa9y+vllNHz3e3d4CNj1PQE4BQYxLme0gKYYBm9YENq+UkEikyZ0XbiGWxYlVw3Rl9O/U8g==
 
 prompts@^2.0.1:
   version "2.0.4"
@@ -7386,11 +7385,6 @@ whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.3:
   integrity sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==
   dependencies:
     iconv-lite "0.4.24"
-
-whatwg-fetch@2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz#dde6a5df315f9d39991aa17621853d720b85566f"
-  integrity sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==
 
 whatwg-fetch@^3.0.0:
   version "3.2.0"


### PR DESCRIPTION
Add an argument to `KeyManager#fetchAuthToken` to check for a given signing key. If provided, check that the source and signer match that key, and throw if not.