### PR TITLE
Trezor: custom prop to add manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 ## In master
 
-## [v0.3.0-rc.1]
+## [v0.3.0-rc.2]
+
+- [KeyManager] Added optional `custom` prop to `signTransaction()` to allow
+  passing additional info.
+- [KeyManager] Trezor wallet: pass manifest info through `custom` prop.
+
+## [v0.3.0-rc.1](https://github.com/stellar/js-stellar-wallets/compare/v0.2.0-rc.2...v0.3.0-rc.1)
 
 **Breaking changes**:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/wallet-sdk",
-  "version": "0.3.0-rc.1",
+  "version": "0.3.0-rc.2",
   "description": "Libraries to help you write Stellar-enabled wallets in Javascript",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "lodash": "^4.17.14",
     "query-string": "^6.4.2",
     "scrypt-async": "^2.0.1",
-    "trezor-connect": "^8.1.9",
+    "trezor-connect": "^8.1.16",
     "tweetnacl": "^1.0.1",
     "tweetnacl-util": "^0.15.0"
   }

--- a/src/KeyManager.ts
+++ b/src/KeyManager.ts
@@ -36,7 +36,9 @@ export interface SignTransactionParams {
   transaction: Transaction;
   id: string;
   password: string;
-  custom?: any;
+  custom?: {
+    [key: string]: any;
+  };
 }
 
 export interface ChangePasswordParams {

--- a/src/KeyManager.ts
+++ b/src/KeyManager.ts
@@ -36,6 +36,7 @@ export interface SignTransactionParams {
   transaction: Transaction;
   id: string;
   password: string;
+  custom?: any;
 }
 
 export interface ChangePasswordParams {
@@ -236,7 +237,7 @@ export class KeyManager {
   public async signTransaction(
     params: SignTransactionParams,
   ): Promise<Transaction> {
-    const { transaction, id, password } = params;
+    const { transaction, id, password, custom } = params;
     let key = this._readFromCache(id);
 
     if (!key) {
@@ -257,6 +258,7 @@ export class KeyManager {
     const signedTransaction = await keyHandler.signTransaction({
       transaction,
       key,
+      custom,
     });
     return signedTransaction;
   }

--- a/src/keyTypeHandlers/trezor.ts
+++ b/src/keyTypeHandlers/trezor.ts
@@ -8,7 +8,7 @@ import { transformTransaction } from "../helpers/trezorTransformTransaction";
 export const trezorHandler: KeyTypeHandler = {
   keyType: KeyType.trezor,
   async signTransaction(params: HandlerSignTransactionParams) {
-    const { transaction, key } = params;
+    const { transaction, key, custom } = params;
 
     if (key.privateKey !== "") {
       throw new Error(
@@ -18,7 +18,19 @@ export const trezorHandler: KeyTypeHandler = {
       );
     }
 
+    if (!custom || !custom.email || !custom.appUrl) {
+      throw new Error(
+        `Trezor Connect manifest with "email" and "appUrl" props is required.
+        Make sure they are passed through "custom" prop.`,
+      );
+    }
+
     try {
+      TrezorConnect.manifest({
+        email: custom.email,
+        appUrl: custom.appUrl,
+      });
+
       const trezorParams = transformTransaction("m/44'/148'/0'", transaction);
       const response = await TrezorConnect.stellarSignTransaction(trezorParams);
 

--- a/src/types/keys.ts
+++ b/src/types/keys.ts
@@ -145,7 +145,9 @@ export interface KeyStore {
 export interface HandlerSignTransactionParams {
   transaction: Transaction;
   key: Key;
-  custom?: any;
+  custom?: {
+    [key: string]: any;
+  };
 }
 
 /**

--- a/src/types/keys.ts
+++ b/src/types/keys.ts
@@ -145,6 +145,7 @@ export interface KeyStore {
 export interface HandlerSignTransactionParams {
   transaction: Transaction;
   key: Key;
+  custom?: any;
 }
 
 /**


### PR DESCRIPTION
Add optional `custom` prop to `signTransaction()` params to handle custom cases where additional info is required. For example, Trezor wallet requires manifest to be set. Without it, the transaction signing will fail.