### PR TITLE
Add .vscode to gitignore 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ compiled
 *.log
 .DS_Store
 docs
+.vscode/


### PR DESCRIPTION
**Why**

People might have a vscode setting for each workspace. This change prevents personal settings from being pushed to the repo.