### PR TITLE
doc update: move asset checker out from the approval provider

### DIFF
--- a/plans/sep8.md
+++ b/plans/sep8.md
@@ -30,6 +30,8 @@ The high-level flow is:
 ### Types
 
 ```ts
+type checkIfTxInvolvesRegulatedAssets = (params: Transaction) => boolean;
+
 type getActionUrl = (params: GetActionParams) => string;
 
 interface GetActionParams {
@@ -41,7 +43,6 @@ interface GetActionParams {
 class ApprovalProvider {
   constructor(approvalServer, regulatedAssets) {}
   approve: (params: ApprovalRequest) => Promise<ApprovalResponse>;
-  needsApproval: (params: Transaction) => boolean;
   fetchActionInBrowser: ({
     response: ActionRequired,
     window: Window,
@@ -97,6 +98,7 @@ interface TransactionRejected extends ApprovalResponse {
 import {
   ApprovalProvider,
   ApprovalResponseType,
+  checkIfTxInvolvesRegulatedAssets,
   getActionUrl,
 } from "wallet-sdk";
 
@@ -107,8 +109,8 @@ const approvalProvider = new ApprovalProvider(
   regulatedAssets,
 );
 
-// Parse transaction to check if involves regulated assets
-const needsApproval = approvalProvider.needsApproval(transaction);
+// Parse transaction to check if it involves regulated assets
+const needsApproval = checkIfTxInvolvesRegulatedAssets(transaction);
 if (!needsApproval) {
   // No approval needed so submit to the network
   submitPayment(transaction);

--- a/plans/sep8.md
+++ b/plans/sep8.md
@@ -5,26 +5,27 @@ Approval service API for transacting with an anchor's regulated assets.
 The high-level flow is:
 
 - User signs a transaction
-- Parse transaction for assets involved, detect whether any assets involved are
-  regulated
-- If regulated, notify user submitting request for transaction approval
-- Submit transaction to approval server, and depending on response:
+- Parse the transaction for assets involved, detect whether any assets involved
+  are regulated
+- If regulated, notify the user to submit a request for transaction approval
+- Submit the transaction to the corresponding approval server, and depending on
+  the response:
   - if success
-    - Display message if included in response
-    - Submit approved tx to the network
+    - Display the message if included in the response
+    - Submit the approved tx to the network
   - if revised
-    - Display message
-    - Parse returned tx, display modifications to user
-    - Prompt user to resign tx
-    - Submit resigned tx to the network
+    - Display the message
+    - Parse the returned tx, display modifications to the user
+    - Prompt the user to re-sign the tx
+    - Submit the resigned tx to the network
   - if pending
-    - Display timeout, message if included in response
-  - if action required
-    - Display message
-    - Redirect to action url
+    - Display the timeout if it is not zero
+    - Display the message if included in the response
+  - if action_required
+    - Display the message
+    - Redirect to action_url
   - if rejected
-    - "approval failed"
-    - Display error
+    - Display the error
 
 ### Types
 

--- a/plans/sep8.md
+++ b/plans/sep8.md
@@ -152,7 +152,7 @@ switch (approvalResponse.status) {
       const popup = window.open("", "name", "dimensions etc");
 
       const actionResult = await approvalProvider.fetchActionInBrowser({
-        response: approvalResult,
+        response: approvalResponse,
         window: popup,
       });
 
@@ -165,7 +165,7 @@ switch (approvalResponse.status) {
       }
     } else if (isServerEnv || isNativeEnv) {
       const actionRedirect = getActionUrl({
-        result: approvalResult,
+        response: approvalResponse,
         request: approvalRequest,
         callbackUrl,
       });


### PR DESCRIPTION
**What**

Besides fixing problems suggested by the grammarly pluggin, this PR moves the check for whether a regulated asset is involved out from the Approval Provider class.

**Why**

Checking whether an asset is a regulated asset doesn't have to be done by the approval provider. That is, one doesn't have to  look at the information in the toml file in order to tell. It can be done by looking at the issuer's [authorization flags](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0008.md#authorization-flags).