### PR TITLE
doc update: remove asset from the constructor of approval provider

### DIFF
--- a/plans/sep8.md
+++ b/plans/sep8.md
@@ -54,6 +54,7 @@ interface GetActionParams {
   callbackUrl: string;
 }
 
+// If we need to support transactions involving multiple regulated assets, the constructor can take an array of approvalServerUrls.
 class ApprovalProvider {
   constructor(approvalServerUrl) {}
   approve: (params: ApprovalRequest) => Promise<ApprovalResponse>;

--- a/plans/sep8.md
+++ b/plans/sep8.md
@@ -30,7 +30,21 @@ The high-level flow is:
 ### Types
 
 ```ts
+// TODO:
+// 1. Think about whether we can handle a transaction involving more than one regulated asset?
+// 2. Make this function return the regulated asset or an array of regulated assets if found.
 type checkIfTxInvolvesRegulatedAssets = (params: Transaction) => boolean;
+
+// Asset issuers usually have the home_domain set in their account.
+type getHomeDomainByAssetIssuer = (params: string) => string;
+
+// Get the approval server's URL by fetching the stellar.toml file at the home domain and look for the matched currency.
+type getApprovalServerUrl = (params: GetApprovalServerUrlRequest) => string;
+
+interface GetApprovalServerUrlReqeust {
+  homeDomain: string;
+  regulatedAsset: string;
+}
 
 type getActionUrl = (params: GetActionParams) => string;
 
@@ -41,7 +55,7 @@ interface GetActionParams {
 }
 
 class ApprovalProvider {
-  constructor(approvalServer, regulatedAssets) {}
+  constructor(approvalServerUrl) {}
   approve: (params: ApprovalRequest) => Promise<ApprovalResponse>;
   fetchActionInBrowser: ({
     response: ActionRequired,


### PR DESCRIPTION
**What**

This PR adds two helper functions for getting the approval server once a regulated asset is found in a transaction. We first need to find the home domain of the asset, then we need to fetch the stellar.toml file and find the asset in the `CURRENCIES` section.

This PR also removes the `regulatedAsset` from the constructor of the approval provider.

**Why**

Once the corresponding approval server is found, we don't really have to provide the regulated asset in order to get an approval. One will need to send the whole transaction to the approval server.
