### PR TITLE
Add SEP-8 types and constants

### DIFF
--- a/plans/sep8.md
+++ b/plans/sep8.md
@@ -100,6 +100,7 @@ interface TransactionRejected extends ApprovalResponse {
 interface PostActionUrlResponse {
   result: string;
   next_url?: string;
+  message?: string;
 }
 ```
 

--- a/src/constants/sep8.ts
+++ b/src/constants/sep8.ts
@@ -1,0 +1,12 @@
+export enum ApprovalResponseStatus {
+  success = "success",
+  revised = "revised",
+  pending = "pending",
+  actionRequired = "action_required",
+  rejected = "rejected",
+}
+
+export enum ActionResult {
+  noFurtherActionRequired = "no_further_action_required",
+  followNextUrl = "follow_next_url",
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ export { Types };
 export { EffectType } from "./constants/data";
 export { KeyType } from "./constants/keys";
 export { TransferResponseType, TransactionStatus } from "./constants/transfers";
+export { ApprovalResponseStatus, ActionResult } from "./constants/sep8";
 
 /**
  * Data

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,3 +2,4 @@ export * from "./data";
 export * from "./keys";
 export * from "./transfers";
 export * from "./watchers";
+export * from "./sep8";

--- a/src/types/sep8.ts
+++ b/src/types/sep8.ts
@@ -1,33 +1,28 @@
 import { ApprovalResponseStatus } from "../constants/sep8";
 
 export interface ApprovalResponse {
-  status:
-    | ApprovalResponseStatus.success
-    | ApprovalResponseStatus.revised
-    | ApprovalResponseStatus.pending
-    | ApprovalResponseStatus.actionRequired
-    | ApprovalResponseStatus.rejected;
+  status: ApprovalResponseStatus;
 }
 
-export interface TransactionApproved extends ApprovalResponse {
+export interface TransactionApproved {
   status: ApprovalResponseStatus.success;
   tx: string;
   message?: string;
 }
 
-export interface TransactionRevised extends ApprovalResponse {
+export interface TransactionRevised {
   status: ApprovalResponseStatus.revised;
   tx: string;
   message: string;
 }
 
-export interface PendingApproval extends ApprovalResponse {
+export interface PendingApproval {
   status: ApprovalResponseStatus.pending;
   timeout: number;
   message?: string;
 }
 
-export interface ActionRequired extends ApprovalResponse {
+export interface ActionRequired {
   status: ApprovalResponseStatus.actionRequired;
   message: string;
   action_url: string;
@@ -35,7 +30,7 @@ export interface ActionRequired extends ApprovalResponse {
   action_fields?: string[];
 }
 
-export interface TransactionRejected extends ApprovalResponse {
+export interface TransactionRejected {
   status: ApprovalResponseStatus.rejected;
   error: string;
 }

--- a/src/types/sep8.ts
+++ b/src/types/sep8.ts
@@ -1,0 +1,47 @@
+import { ApprovalResponseStatus } from "../constants/sep8";
+
+export interface ApprovalResponse {
+  status:
+    | ApprovalResponseStatus.success
+    | ApprovalResponseStatus.revised
+    | ApprovalResponseStatus.pending
+    | ApprovalResponseStatus.actionRequired
+    | ApprovalResponseStatus.rejected;
+}
+
+export interface TransactionApproved extends ApprovalResponse {
+  status: ApprovalResponseStatus.success;
+  tx: string;
+  message?: string;
+}
+
+export interface TransactionRevised extends ApprovalResponse {
+  status: ApprovalResponseStatus.revised;
+  tx: string;
+  message: string;
+}
+
+export interface PendingApproval extends ApprovalResponse {
+  status: ApprovalResponseStatus.pending;
+  timeout: number;
+  message?: string;
+}
+
+export interface ActionRequired extends ApprovalResponse {
+  status: ApprovalResponseStatus.actionRequired;
+  message: string;
+  action_url: string;
+  action_method?: string;
+  action_fields?: string[];
+}
+
+export interface TransactionRejected extends ApprovalResponse {
+  status: ApprovalResponseStatus.rejected;
+  error: string;
+}
+
+export interface PostActionUrlResponse {
+  result: string;
+  next_url?: string;
+  message?: string;
+}


### PR DESCRIPTION
**What**

This PR introduces SEP-8 types and constants. This PR also adds one extra field to the `PostActionUrlResponse` as SEP-8 has been updated.

**Next**

1. I'll be implementing the "approve" function in ApprovalProvider.
2. I'll be implementing the "postActionUrl" function in ApprovalProvider.
3. I'll be adding the helper functions to find the approval server URL.