### PR TITLE
Add SEP-8 Approval Provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 ## In master
 
+- Added SEP-8 Approval Provider.
+
 ## [v0.3.0-rc.4](https://github.com/stellar/js-stellar-wallets/compare/v0.3.0-rc.3...v0.3.0-rc.4)
 
 - Upgraded Ledger dependencies.
 
-## [v0.3.0-rc.3]
+## [v0.3.0-rc.3](https://github.com/stellar/js-stellar-wallets/compare/v0.3.0-rc.2...v0.3.0-rc.3)
 
 - [KeyManager] Renamed Lyra to Freighter.
 

--- a/src/sep8/ApprovalProvider.test.ts
+++ b/src/sep8/ApprovalProvider.test.ts
@@ -257,8 +257,8 @@ describe("approve", () => {
       expect(res).toEqual(actionRequired);
       expect(res.status).toBe(ApprovalResponseStatus.actionRequired);
       const resActionRequired = res as ActionRequired;
-      expect(resActionRequired.action_url).toBeDefined();
-      expect(resActionRequired.message).toBeDefined();
+      expect(resActionRequired.action_url).toBeTruthy();
+      expect(resActionRequired.message).toBeTruthy();
     } catch (e) {
       expect(e).toBe(null);
     }
@@ -293,7 +293,7 @@ describe("approve", () => {
       expect(res).toEqual(rejected);
       expect(res.status).toBe(ApprovalResponseStatus.rejected);
       const txRejected = res as TransactionRejected;
-      expect(txRejected.error).toBeDefined();
+      expect(txRejected.error).toBeTruthy();
     } catch (e) {
       expect(e).toBe(null);
     }

--- a/src/sep8/ApprovalProvider.test.ts
+++ b/src/sep8/ApprovalProvider.test.ts
@@ -1,0 +1,237 @@
+import StellarBase from "stellar-base";
+import { ApprovalResponseStatus } from "../constants/sep8";
+import {
+  ActionRequired,
+  PendingApproval,
+  TransactionApproved,
+  TransactionRejected,
+  TransactionRevised,
+} from "../types/sep8";
+import { ApprovalProvider } from "./ApprovalProvider";
+
+describe("ApprovalProvider", () => {
+  test("Throws errors for missing param", async () => {
+    try {
+      // @ts-ignore
+      const approvalProvider = new ApprovalProvider("");
+      expect("This test failed").toBe(null);
+    } catch (e) {
+      expect(e).toBeTruthy();
+    }
+  });
+});
+
+describe("approve", () => {
+  beforeEach(() => {
+    // @ts-ignore
+    fetch.resetMocks();
+  });
+
+  test("transaction has no signature", async () => {
+    const accountKey = StellarBase.Keypair.random();
+    const account = new StellarBase.Account(accountKey.publicKey(), "0");
+    const keyNetwork = StellarBase.Networks.TESTNET;
+
+    const txBuild = new StellarBase.TransactionBuilder(account, {
+      fee: "10000",
+      networkPassphrase: keyNetwork,
+    })
+      .setTimeout(1000)
+      .build();
+
+    const approvalServer = "https://www.stellar.org/approve";
+    const approvalProvider = new ApprovalProvider(approvalServer);
+    try {
+      // @ts-ignore
+      await approvalProvider.approve(txBuild);
+      expect("This test failed").toBe(null);
+    } catch (e) {
+      expect(e.toString()).toMatch(
+        `At least one signature is required before submitting for approval.`,
+      );
+    }
+  });
+
+  test("success response", async () => {
+    const accountKey = StellarBase.Keypair.random();
+    const account = new StellarBase.Account(accountKey.publicKey(), "0");
+    const keyNetwork = StellarBase.Networks.TESTNET;
+
+    const txBuild = new StellarBase.TransactionBuilder(account, {
+      fee: "10000",
+      networkPassphrase: keyNetwork,
+    })
+      .setTimeout(1000)
+      .build();
+    txBuild.sign(accountKey);
+
+    const tx = txBuild.toXDR();
+
+    const success = {
+      status: "success",
+      tx,
+    };
+
+    // @ts-ignore
+    fetch.mockResponseOnce(JSON.stringify(success));
+
+    const approvalServer = "https://www.stellar.org/approve";
+    const approvalProvider = new ApprovalProvider(approvalServer);
+
+    try {
+      const res = await approvalProvider.approve(txBuild);
+      expect(res).toEqual(success);
+      expect(res.status).toBe(ApprovalResponseStatus.success);
+      const txApproved = res as TransactionApproved;
+      expect(txApproved.tx).toBe(tx);
+    } catch (e) {
+      expect(e).toBe(null);
+    }
+  });
+
+  test("revised response", async () => {
+    const accountKey = StellarBase.Keypair.random();
+    const account = new StellarBase.Account(accountKey.publicKey(), "0");
+    const keyNetwork = StellarBase.Networks.TESTNET;
+
+    const txBuild = new StellarBase.TransactionBuilder(account, {
+      fee: "10000",
+      networkPassphrase: keyNetwork,
+    })
+      .setTimeout(1000)
+      .build();
+    txBuild.sign(accountKey);
+
+    const tx = txBuild.toXDR();
+
+    const revised = {
+      status: "revised",
+      tx: "This is a base64-encoded transaction revised by the approval server",
+      message: "Added authorization and deauthorization operations",
+    };
+
+    // @ts-ignore
+    fetch.mockResponseOnce(JSON.stringify(revised));
+
+    const approvalServer = "https://www.stellar.org/approve";
+    const approvalProvider = new ApprovalProvider(approvalServer);
+
+    try {
+      const res = await approvalProvider.approve(txBuild);
+      expect(res).toEqual(revised);
+      expect(res.status).toBe(ApprovalResponseStatus.revised);
+      const txRevised = res as TransactionRevised;
+      expect(txRevised.tx).not.toMatch(tx);
+      expect(txRevised.message).toBeTruthy();
+    } catch (e) {
+      expect(e).toBe(null);
+    }
+  });
+
+  test("pending response", async () => {
+    const accountKey = StellarBase.Keypair.random();
+    const account = new StellarBase.Account(accountKey.publicKey(), "0");
+    const keyNetwork = StellarBase.Networks.TESTNET;
+
+    const txBuild = new StellarBase.TransactionBuilder(account, {
+      fee: "10000",
+      networkPassphrase: keyNetwork,
+    })
+      .setTimeout(1000)
+      .build();
+    txBuild.sign(accountKey);
+
+    const pending = {
+      status: "pending",
+      timeout: 0,
+    };
+
+    // @ts-ignore
+    fetch.mockResponseOnce(JSON.stringify(pending));
+
+    const approvalServer = "https://www.stellar.org/approve";
+    const approvalProvider = new ApprovalProvider(approvalServer);
+
+    try {
+      const res = await approvalProvider.approve(txBuild);
+      expect(res).toEqual(pending);
+      expect(res.status).toBe(ApprovalResponseStatus.pending);
+      const txPending = res as PendingApproval;
+      expect(txPending.timeout).toBeGreaterThanOrEqual(0);
+    } catch (e) {
+      expect(e).toBe(null);
+    }
+  });
+
+  test("action required response", async () => {
+    const accountKey = StellarBase.Keypair.random();
+    const account = new StellarBase.Account(accountKey.publicKey(), "0");
+    const keyNetwork = StellarBase.Networks.TESTNET;
+
+    const txBuild = new StellarBase.TransactionBuilder(account, {
+      fee: "10000",
+      networkPassphrase: keyNetwork,
+    })
+      .setTimeout(1000)
+      .build();
+    txBuild.sign(accountKey);
+
+    const actionRequired = {
+      status: "action_required",
+      action_url: "the url to provide the required actions",
+      message: "Please provide extra information",
+    };
+
+    // @ts-ignore
+    fetch.mockResponseOnce(JSON.stringify(actionRequired));
+
+    const approvalServer = "https://www.stellar.org/approve";
+    const approvalProvider = new ApprovalProvider(approvalServer);
+
+    try {
+      const res = await approvalProvider.approve(txBuild);
+      expect(res).toEqual(actionRequired);
+      expect(res.status).toBe(ApprovalResponseStatus.actionRequired);
+      const resActionRequired = res as ActionRequired;
+      expect(resActionRequired.action_url).toBeDefined();
+      expect(resActionRequired.message).toBeDefined();
+    } catch (e) {
+      expect(e).toBe(null);
+    }
+  });
+
+  test("rejected response", async () => {
+    const accountKey = StellarBase.Keypair.random();
+    const account = new StellarBase.Account(accountKey.publicKey(), "0");
+    const keyNetwork = StellarBase.Networks.TESTNET;
+
+    const txBuild = new StellarBase.TransactionBuilder(account, {
+      fee: "10000",
+      networkPassphrase: keyNetwork,
+    })
+      .setTimeout(1000)
+      .build();
+    txBuild.sign(accountKey);
+
+    const rejected = {
+      status: "rejected",
+      error: "The destination account is blocked.",
+    };
+
+    // @ts-ignore
+    fetch.mockResponseOnce(JSON.stringify(rejected));
+
+    const approvalServer = "https://www.stellar.org/approve";
+    const approvalProvider = new ApprovalProvider(approvalServer);
+
+    try {
+      const res = await approvalProvider.approve(txBuild);
+      expect(res).toEqual(rejected);
+      expect(res.status).toBe(ApprovalResponseStatus.rejected);
+      const txRejected = res as TransactionRejected;
+      expect(txRejected.error).toBeDefined();
+    } catch (e) {
+      expect(e).toBe(null);
+    }
+  });
+});

--- a/src/sep8/ApprovalProvider.ts
+++ b/src/sep8/ApprovalProvider.ts
@@ -72,13 +72,14 @@ export class ApprovalProvider {
       );
     }
 
-    if (
-      res.status !== ApprovalResponseStatus.success &&
-      res.status !== ApprovalResponseStatus.revised &&
-      res.status !== ApprovalResponseStatus.pending &&
-      res.status !== ApprovalResponseStatus.actionRequired &&
-      res.status !== ApprovalResponseStatus.rejected
-    ) {
+    const acceptedStatuses = [
+      ApprovalResponseStatus.success,
+      ApprovalResponseStatus.revised,
+      ApprovalResponseStatus.pending,
+      ApprovalResponseStatus.actionRequired,
+      ApprovalResponseStatus.rejected,
+    ];
+    if (!acceptedStatuses.includes(res.status)) {
       throw new Error(`Approval server returned unknown status: ${res.status}`);
     }
     return res;

--- a/src/sep8/ApprovalProvider.ts
+++ b/src/sep8/ApprovalProvider.ts
@@ -1,0 +1,77 @@
+import { Transaction } from "stellar-base";
+import { ApprovalResponse } from "../types/sep8";
+
+export class ApprovalProvider {
+  public approvalServer: string;
+
+  constructor(approvalServer: string) {
+    if (!approvalServer) {
+      throw new Error("Required parameter `approvalServer` missing!");
+    }
+
+    this.approvalServer = approvalServer.replace(/\/$/, "");
+  }
+
+  public async approve(
+    transaction: Transaction,
+    contentType:
+      | "application/json"
+      | "application/x-www-form-urlencoded" = "application/json",
+  ): Promise<ApprovalResponse> {
+    const param = {
+      tx: transaction
+        .toEnvelope()
+        .toXDR()
+        .toString("base64"),
+    };
+
+    let response;
+    if (contentType === "application/json") {
+      response = await fetch(this.approvalServer, {
+        method: "POST",
+        body: JSON.stringify(param),
+        headers: {
+          "Content-Type": "application/json",
+        },
+      });
+    } else {
+      const urlParam = new URLSearchParams(param);
+      response = await fetch(this.approvalServer, {
+        method: "POST",
+        body: urlParam.toString(),
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
+      });
+    }
+
+    if (!response.ok) {
+      const responseText = await response.text();
+      try {
+        const { responseJson } = JSON.parse(responseText);
+        throw new Error(
+          `Error sending base64-encoded transaction to ${
+            this.approvalServer
+          }: error ${responseJson.error}`,
+        );
+      } catch (e) {
+        throw new Error(
+          `Error sending base64-encoded transaction to ${
+            this.approvalServer
+          }: error 
+          code ${response.status}, status text: "${responseText}"`,
+        );
+      }
+    }
+
+    const responseOKText = await response.text();
+
+    try {
+      return JSON.parse(responseOKText) as ApprovalResponse;
+    } catch (e) {
+      throw new Error(
+        `Error parsing the approval server response as JSON: ${responseOKText}`,
+      );
+    }
+  }
+}

--- a/src/sep8/ApprovalProvider.ts
+++ b/src/sep8/ApprovalProvider.ts
@@ -1,4 +1,5 @@
 import { Transaction } from "stellar-base";
+import { FeeBumpTransaction } from "stellar-sdk";
 import { ApprovalResponse } from "../types/sep8";
 
 export class ApprovalProvider {
@@ -13,11 +14,17 @@ export class ApprovalProvider {
   }
 
   public async approve(
-    transaction: Transaction,
+    transaction: Transaction | FeeBumpTransaction,
     contentType:
       | "application/json"
       | "application/x-www-form-urlencoded" = "application/json",
   ): Promise<ApprovalResponse> {
+    if (!transaction.signatures.length) {
+      throw new Error(
+        "At least one signature is required before submitting for approval.",
+      );
+    }
+
     const param = {
       tx: transaction
         .toEnvelope()

--- a/src/sep8/ApprovalProvider.ts
+++ b/src/sep8/ApprovalProvider.ts
@@ -55,21 +55,11 @@ export class ApprovalProvider {
 
     if (!response.ok) {
       const responseText = await response.text();
-      try {
-        const { responseJson } = JSON.parse(responseText);
-        throw new Error(
-          `Error sending base64-encoded transaction to ${
-            this.approvalServer
-          }: error ${responseJson.error}`,
-        );
-      } catch (e) {
-        throw new Error(
-          `Error sending base64-encoded transaction to ${
-            this.approvalServer
-          }: error 
-          code ${response.status}, status text: "${responseText}"`,
-        );
-      }
+      throw new Error(
+        `Error sending base64-encoded transaction to ${
+          this.approvalServer
+        }: error code ${response.status}, status text: "${responseText}"`,
+      );
     }
 
     const responseOKText = await response.text();


### PR DESCRIPTION
**What**

This PR adds a new SEP-8 approval provider class. This also implements the `approve` method, which sends POST request to the approval server.

**Next**

1. implement the "postActionUrl" function in ApprovalProvider.
2. add the helper functions to find the approval server URL.