### PR TITLE
Add postActionUrl method to Approval Provider

### DIFF
--- a/src/sep8/ApprovalProvider.ts
+++ b/src/sep8/ApprovalProvider.ts
@@ -95,10 +95,7 @@ export class ApprovalProvider {
     if (!params.action_url) {
       throw new Error("Required field 'action_url' missing!");
     }
-    if (
-      !Object.keys(params.field_value_map) ||
-      !Object.keys(params.field_value_map).length
-    ) {
+    if (!Object.keys(params.field_value_map).length) {
       throw new Error("Required field 'field_value_map' missing!");
     }
 

--- a/src/types/sep8.ts
+++ b/src/types/sep8.ts
@@ -1,4 +1,4 @@
-import { ApprovalResponseStatus } from "../constants/sep8";
+import { ActionResult, ApprovalResponseStatus } from "../constants/sep8";
 
 export interface ApprovalResponse {
   status: ApprovalResponseStatus;
@@ -41,7 +41,7 @@ export interface PostActionUrlRequest {
 }
 
 export interface PostActionUrlResponse {
-  result: string;
+  result: ActionResult;
   next_url?: string;
   message?: string;
 }

--- a/src/types/sep8.ts
+++ b/src/types/sep8.ts
@@ -35,6 +35,11 @@ export interface TransactionRejected {
   error: string;
 }
 
+export interface PostActionUrlRequest {
+  action_url: string;
+  field_value_map: { [key: string]: any };
+}
+
 export interface PostActionUrlResponse {
   result: string;
   next_url?: string;


### PR DESCRIPTION
**What**

This PR implements the `postActionUrl` method in the Approval server.

**Why**

When an approval server returns an `action_required` response, the client can use the `postActionUrl` method to send information to the address designated by `action_url` in the background.

**Next**

Add the helper functions to find the approval server URL.