### PR TITLE
plan update: simplify SEP-8 helper functions

### DIFF
--- a/src/types/sep8.ts
+++ b/src/types/sep8.ts
@@ -45,3 +45,9 @@ export interface PostActionUrlResponse {
   next_url?: string;
   message?: string;
 }
+
+export interface RegulatedAssetInfo {
+  asset_code: string;
+  asset_issuer: string;
+  home_domain?: string;
+}


### PR DESCRIPTION
**What**

This PR simplifies the helper functions planned by removing a redundant one.

**Why**

When we check whether an asset is regulated via Horizon, we already need to make the /account call to check the flags. Home domain information will be included in the account object. This change avoids one extra round trip to Horizon.