### PR TITLE
fix claimable balance id in test

### DIFF
--- a/src/sep8/getRegulatedAssetsinTx.test.ts
+++ b/src/sep8/getRegulatedAssetsinTx.test.ts
@@ -930,7 +930,8 @@ describe("getRegulatedAssetsInTx with ops moving regulated assets", () => {
     const raIssuer = "GB2MIGFFC7IIEVAJ4OHTEH3GDLIEFE3K2RYLT3LPGZEKDDAH4FL3FPSJ";
     const homeDomain = "https://regulated-asset-issuer-home-domain.com";
     const balanceId =
-      "00000000929b20b72e5890ab51c24f1cc46fa01c4f318d8d33367d24dd614cfdf54910";
+      "00000000929b20b72e5890ab51c24f1cc46fa01c4f318d8d33367d24dd614cfdf54910" +
+      "72";
     const balanceResponse = {
       _links: {},
       id: balanceId,
@@ -1432,7 +1433,8 @@ describe("getRegulatedAssetsInTx with ops moving nonregulated assets", () => {
     const usdIssuer =
       "GB2MIGFFC7IIEVAJ4OHTEH3GDLIEFE3K2RYLT3LPGZEKDDAH4FL3FPSJ";
     const balanceId =
-      "00000000929b20b72e5890ab51c24f1cc46fa01c4f318d8d33367d24dd614cfdf54910";
+      "00000000929b20b72e5890ab51c24f1cc46fa01c4f318d8d33367d24dd614cfdf54910" +
+      "72";
     const balanceResponse = {
       _links: {},
       id: balanceId,


### PR DESCRIPTION
We had a failed [test](https://app.circleci.com/pipelines/github/stellar/js-stellar-wallets/595/workflows/dac63c6f-fccf-40c6-9e40-46d258752eac/jobs/697) because of the balance ID being too short. For some reason, it didn't happen locally.

I've created an [issue](https://github.com/stellar/js-stellar-base/issues/388) in the stellar-base repo.