### PR TITLE
Make sure "kind" param works on fetchTransactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## In master
 
+## [v0.9.0](https://github.com/stellar/js-stellar-wallets/compare/v0.8.0...v0.9.0)
+
+- Make sure "kind" param works on fetchTransactions
+
+## [v0.8.0](https://github.com/stellar/js-stellar-wallets/compare/v0.7.0-rc.0...v0.8.0)
+
+- Update stellar-sdk and add keystore support for browser storage
+
 ## [v0.7.0-rc.0](https://github.com/stellar/js-stellar-wallets/compare/v0.6.0-rc.1...v0.7.0-rc.0)
 
 This release updates the SDK to accommodate latest changes from [SEP-24 spec](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0024.md#changelog):

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stellar/wallet-sdk",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Libraries to help you write Stellar-enabled wallets in Javascript",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/transfers/TransferProvider.ts
+++ b/src/transfers/TransferProvider.ts
@@ -204,7 +204,7 @@ export abstract class TransferProvider {
 
     if (!params.show_all_transactions) {
       kind =
-        params.kind || this.operation === "deposit" ? "deposit" : "withdrawal";
+        params.kind || (this.operation === "deposit" ? "deposit" : "withdrawal");
     }
 
     const response = await fetch(


### PR DESCRIPTION
This is how js is currently processing the expression:
`kind = (params.kind || this.operation === "deposit") ? "deposit" : "withdrawal";`

This is how it's supposed to work:
`kind  = params.kind || (this.operation === "deposit" ? "deposit" : "withdrawal");`

People usually don't need to manually set the `params.kind` parameter as falling back to `this.operation` should work in most cases, that's probably why this bug was not caught yet.